### PR TITLE
fix(DiscordNotification): make embeds to nullable

### DIFF
--- a/database/migrations/2022_05_24_122756_make_embed_nullable_in_discord_notifications.php
+++ b/database/migrations/2022_05_24_122756_make_embed_nullable_in_discord_notifications.php
@@ -14,7 +14,7 @@ return new class extends Migration
     public function up()
     {
         Schema::table('discord_notifications', function (Blueprint $table) {
-            $table->json('embeds')->after('content');
+            $table->json('embeds')->nullable()->change();
         });
     }
 
@@ -26,7 +26,7 @@ return new class extends Migration
     public function down()
     {
         Schema::table('discord_notifications', function (Blueprint $table) {
-            $table->dropColumn('embeds');
+            $table->json('embeds')->nullable(false)->change();
         });
     }
 };


### PR DESCRIPTION
Not sure if previous things are already live. If it is, I can move this to a new migration