### PR TITLE
fix: re-add missing code for saving filters

### DIFF
--- a/app/Filament/Resources/FlowMeasureResource/Pages/EditFlowMeasure.php
+++ b/app/Filament/Resources/FlowMeasureResource/Pages/EditFlowMeasure.php
@@ -93,6 +93,12 @@ class EditFlowMeasure extends EditRecord
                 'type' => 'ADES',
                 'value' => $this->getAirportValues($data, 'ades')
             ]);
+
+        $data['filters'] = $filters->toArray();
+        Arr::pull($data, 'adep');
+        Arr::pull($data, 'ades');
+
+        return $data;
     }
 
     private function buildAirportFilter(string $value): array


### PR DESCRIPTION
This looks like it went missing at some point around https://github.com/ECFMP/flow/commit/8ae82db56b930c277cdeff94544e922c72ef2b26 and seems to break when editing flow measures.

Commit also present in #86 but cherry-picked it out separately too.