### PR TITLE
feat: send issued by to discord

### DIFF
--- a/app/Discord/FlowMeasure/Embed/ActivatedEmbeds.php
+++ b/app/Discord/FlowMeasure/Embed/ActivatedEmbeds.php
@@ -8,6 +8,7 @@ use App\Discord\FlowMeasure\Field\ArrivalAirports;
 use App\Discord\FlowMeasure\Field\DepartureAirports;
 use App\Discord\FlowMeasure\Field\EndTime;
 use App\Discord\FlowMeasure\Field\Filters\AdditionalFilterParser;
+use App\Discord\FlowMeasure\Field\IssuingUser;
 use App\Discord\FlowMeasure\Field\Reason;
 use App\Discord\FlowMeasure\Field\Restriction;
 use App\Discord\FlowMeasure\Field\StartTime;
@@ -38,6 +39,7 @@ class ActivatedEmbeds implements FlowMeasureEmbedInterface
                         : IdentifierAndActiveStatus::create($this->pendingMessage->flowMeasure())
                 )
                 ->withDescription(new EventName($this->pendingMessage->flowMeasure()))
+                ->withField(Field::make(new IssuingUser($this->pendingMessage->flowMeasure())), is_null($this->pendingMessage->webhook()->id()))
                 ->withField(Field::makeInline(new Restriction($this->pendingMessage->flowMeasure())))
                 ->withField(Field::makeInline(new StartTime($this->pendingMessage->flowMeasure())))
                 ->withField(Field::makeInline(new EndTime($this->pendingMessage->flowMeasure())))

--- a/app/Discord/FlowMeasure/Embed/NotifiedEmbeds.php
+++ b/app/Discord/FlowMeasure/Embed/NotifiedEmbeds.php
@@ -8,6 +8,7 @@ use App\Discord\FlowMeasure\Field\ArrivalAirports;
 use App\Discord\FlowMeasure\Field\DepartureAirports;
 use App\Discord\FlowMeasure\Field\EndTime;
 use App\Discord\FlowMeasure\Field\Filters\AdditionalFilterParser;
+use App\Discord\FlowMeasure\Field\IssuingUser;
 use App\Discord\FlowMeasure\Field\Reason;
 use App\Discord\FlowMeasure\Field\Restriction;
 use App\Discord\FlowMeasure\Field\StartTime;
@@ -38,6 +39,7 @@ class NotifiedEmbeds implements FlowMeasureEmbedInterface
                         : IdentifierAndNotifiedStatus::create($this->pendingMessage->flowMeasure())
                 )
                 ->withDescription(new EventName($this->pendingMessage->flowMeasure()))
+                ->withField(Field::make(new IssuingUser($this->pendingMessage->flowMeasure())), is_null($this->pendingMessage->webhook()->id()))
                 ->withField(Field::makeInline(new Restriction($this->pendingMessage->flowMeasure())))
                 ->withField(Field::makeInline(new StartTime($this->pendingMessage->flowMeasure())))
                 ->withField(Field::makeInline(new EndTime($this->pendingMessage->flowMeasure())))

--- a/app/Discord/FlowMeasure/Field/IssuingUser.php
+++ b/app/Discord/FlowMeasure/Field/IssuingUser.php
@@ -11,6 +11,6 @@ class IssuingUser extends AbstractFlowMeasureField
 
     public function value(): string
     {
-        return $this->flowMeasure->user->name;
+        return $this->flowMeasure->user->nameAndCid;
     }
 }

--- a/app/Discord/FlowMeasure/Field/IssuingUser.php
+++ b/app/Discord/FlowMeasure/Field/IssuingUser.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Discord\FlowMeasure\Field;
+
+class IssuingUser extends AbstractFlowMeasureField
+{
+    public function name(): string
+    {
+        return 'Issued By';
+    }
+
+    public function value(): string
+    {
+        return $this->flowMeasure->user->name;
+    }
+}

--- a/app/Discord/Message/Embed/Embed.php
+++ b/app/Discord/Message/Embed/Embed.php
@@ -51,9 +51,11 @@ class Embed implements EmbedInterface
         return $this;
     }
 
-    public function withField(FieldInterface $field): static
+    public function withField(FieldInterface $field, bool $condition = true): static
     {
-        $this->fields->add($field);
+        if ($condition) {
+            $this->fields->add($field);
+        }
 
         return $this;
     }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -3,13 +3,14 @@
 namespace App\Models;
 
 use App\Enums\RoleKey;
-use Illuminate\Notifications\Notifiable;
 use Filament\Models\Contracts\FilamentUser;
-use Illuminate\Database\Eloquent\Relations\HasMany;
-use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
-use Illuminate\Foundation\Auth\User as Authenticatable;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Foundation\Auth\User as Authenticatable;
+use Illuminate\Notifications\Notifiable;
 
 class User extends Authenticatable implements FilamentUser
 {
@@ -70,5 +71,10 @@ class User extends Authenticatable implements FilamentUser
             default:
                 return [];
         }
+    }
+
+    public function nameAndCid(): Attribute
+    {
+        return Attribute::get(fn () => sprintf('%s (%d)', $this->name, $this->id));
     }
 }

--- a/tests/Discord/FlowMeasure/Embed/ActivatedEmbedsTest.php
+++ b/tests/Discord/FlowMeasure/Embed/ActivatedEmbedsTest.php
@@ -56,7 +56,7 @@ class ActivatedEmbedsTest extends TestCase
                     'fields' => [
                         [
                             'name' => 'Issued By',
-                            'value' => $measure->user->name,
+                            'value' => $measure->user->nameAndCid,
                             'inline' => false,
                         ],
                         [
@@ -131,7 +131,7 @@ class ActivatedEmbedsTest extends TestCase
                     'fields' => [
                         [
                             'name' => 'Issued By',
-                            'value' => $measure->user->name,
+                            'value' => $measure->user->nameAndCid,
                             'inline' => false,
                         ],
                         [

--- a/tests/Discord/FlowMeasure/Embed/ActivatedEmbedsTest.php
+++ b/tests/Discord/FlowMeasure/Embed/ActivatedEmbedsTest.php
@@ -7,6 +7,7 @@ use App\Discord\FlowMeasure\Embed\ActivatedEmbeds;
 use App\Discord\FlowMeasure\Helper\NotificationReissuerInterface;
 use App\Discord\FlowMeasure\Provider\PendingMessageInterface;
 use App\Discord\Message\Embed\Colour;
+use App\Discord\Webhook\WebhookInterface;
 use App\Models\DiscordTag;
 use App\Models\FlightInformationRegion;
 use App\Models\FlowMeasure;
@@ -19,12 +20,14 @@ class ActivatedEmbedsTest extends TestCase
     private readonly PendingMessageInterface $pendingMessage;
     private readonly NotificationReissuerInterface $reissuer;
     private readonly ActivatedEmbeds $embeds;
+    private readonly WebhookInterface $webhook;
 
     public function setUp(): void
     {
         parent::setUp();
         $this->pendingMessage = Mockery::mock(PendingMessageInterface::class);
         $this->reissuer = Mockery::mock(NotificationReissuerInterface::class);
+        $this->webhook = Mockery::mock(WebhookInterface::class);
         $this->embeds = new ActivatedEmbeds($this->pendingMessage);
     }
 
@@ -40,7 +43,9 @@ class ActivatedEmbedsTest extends TestCase
 
         $this->pendingMessage->shouldReceive('flowMeasure')->andReturn($measure);
         $this->pendingMessage->shouldReceive('reissue')->andReturn($this->reissuer);
+        $this->pendingMessage->shouldReceive('webhook')->andReturn($this->webhook);
         $this->reissuer->shouldReceive('isReissuedNotification')->andReturn(false);
+        $this->webhook->shouldReceive('id')->andReturnNull();
 
         $this->assertEquals(
             [
@@ -49,6 +54,11 @@ class ActivatedEmbedsTest extends TestCase
                     'color' => Colour::ACTIVATED->value,
                     'description' => (new EventName($measure))->description(),
                     'fields' => [
+                        [
+                            'name' => 'Issued By',
+                            'value' => $measure->user->name,
+                            'inline' => false,
+                        ],
                         [
                             'name' => 'Minimum Departure Interval [MDI]',
                             'value' => '2 Minutes',
@@ -108,12 +118,89 @@ class ActivatedEmbedsTest extends TestCase
 
         $this->pendingMessage->shouldReceive('flowMeasure')->andReturn($measure);
         $this->pendingMessage->shouldReceive('reissue')->andReturn($this->reissuer);
+        $this->pendingMessage->shouldReceive('webhook')->andReturn($this->webhook);
         $this->reissuer->shouldReceive('isReissuedNotification')->andReturn(true);
+        $this->webhook->shouldReceive('id')->andReturnNull();
 
         $this->assertEquals(
             [
                 [
                     'title' => $measure->identifier . ' - ' . 'Active (Reissued)',
+                    'color' => Colour::ACTIVATED->value,
+                    'description' => (new EventName($measure))->description(),
+                    'fields' => [
+                        [
+                            'name' => 'Issued By',
+                            'value' => $measure->user->name,
+                            'inline' => false,
+                        ],
+                        [
+                            'name' => 'Minimum Departure Interval [MDI]',
+                            'value' => '2 Minutes',
+                            'inline' => true,
+                        ],
+                        [
+                            'name' => 'Start Time',
+                            'value' => '22/05 1454Z',
+                            'inline' => true,
+                        ],
+                        [
+                            'name' => 'End Time',
+                            'value' => '1637Z',
+                            'inline' => true,
+                        ],
+                        [
+                            'name' => 'Departure Airports',
+                            'value' => 'EG\\*\\*',
+                            'inline' => true,
+                        ],
+                        [
+                            'name' => 'Arrival Airports',
+                            'value' => 'EHAM',
+                            'inline' => true,
+                        ],
+                        [
+                            'name' => "Applicable To FIR(s)",
+                            'value' => $fir->identifier,
+                            'inline' => true,
+                        ],
+                        [
+                            'name' => 'Level at or Below',
+                            'value' => '220',
+                            'inline' => false,
+                        ],
+                        [
+                            'name' => 'Reason',
+                            'value' => $measure->reason,
+                            'inline' => false,
+                        ],
+                    ],
+                ],
+            ],
+            $this->embeds->embeds()->toArray()
+        );
+    }
+
+    public function testItHasEmbedsWithoutIssuedByIfDivisionWebhook()
+    {
+        $measure = FlowMeasure::factory()
+            ->withTimes(Carbon::parse('2022-05-22T14:54:23Z'), Carbon::parse('2022-05-22T16:37:22Z'))
+            ->withEvent()
+            ->withAdditionalFilter(['type' => 'level_below', 'value' => 220])->create();
+
+        $fir = FlightInformationRegion::factory()->has(DiscordTag::factory()->count(2))->create();
+        $measure->notifiedFlightInformationRegions()->sync([$fir->id]);
+
+        $this->pendingMessage->shouldReceive('flowMeasure')->andReturn($measure);
+        $this->pendingMessage->shouldReceive('reissue')->andReturn($this->reissuer);
+        $this->pendingMessage->shouldReceive('webhook')->andReturn($this->webhook);
+        $this->reissuer->shouldReceive('isReissuedNotification')->andReturn(false);
+        $this->webhook->shouldReceive('id')->andReturn(1);
+
+        $this->assertEquals(
+            [
+                [
+                    'title' => $measure->identifier . ' - ' . 'Active',
                     'color' => Colour::ACTIVATED->value,
                     'description' => (new EventName($measure))->description(),
                     'fields' => [

--- a/tests/Discord/FlowMeasure/Embed/NotifiedEmbedsTest.php
+++ b/tests/Discord/FlowMeasure/Embed/NotifiedEmbedsTest.php
@@ -56,7 +56,7 @@ class NotifiedEmbedsTest extends TestCase
                     'fields' => [
                         [
                             'name' => 'Issued By',
-                            'value' => $measure->user->name,
+                            'value' => $measure->user->nameAndCid,
                             'inline' => false,
                         ],
                         [
@@ -131,7 +131,7 @@ class NotifiedEmbedsTest extends TestCase
                     'fields' => [
                         [
                             'name' => 'Issued By',
-                            'value' => $measure->user->name,
+                            'value' => $measure->user->nameAndCid,
                             'inline' => false,
                         ],
                         [

--- a/tests/Discord/FlowMeasure/Embed/NotifiedEmbedsTest.php
+++ b/tests/Discord/FlowMeasure/Embed/NotifiedEmbedsTest.php
@@ -7,6 +7,7 @@ use App\Discord\FlowMeasure\Embed\NotifiedEmbeds;
 use App\Discord\FlowMeasure\Helper\NotificationReissuerInterface;
 use App\Discord\FlowMeasure\Provider\PendingMessageInterface;
 use App\Discord\Message\Embed\Colour;
+use App\Discord\Webhook\WebhookInterface;
 use App\Models\DiscordTag;
 use App\Models\FlightInformationRegion;
 use App\Models\FlowMeasure;
@@ -19,12 +20,14 @@ class NotifiedEmbedsTest extends TestCase
     private readonly PendingMessageInterface $pendingMessage;
     private readonly NotificationReissuerInterface $reissuer;
     private readonly NotifiedEmbeds $embeds;
+    private readonly WebhookInterface $webhook;
 
     public function setUp(): void
     {
         parent::setUp();
         $this->pendingMessage = Mockery::mock(PendingMessageInterface::class);
         $this->reissuer = Mockery::mock(NotificationReissuerInterface::class);
+        $this->webhook = Mockery::mock(WebhookInterface::class);
         $this->embeds = new NotifiedEmbeds($this->pendingMessage);
     }
 
@@ -40,7 +43,9 @@ class NotifiedEmbedsTest extends TestCase
 
         $this->pendingMessage->shouldReceive('flowMeasure')->andReturn($measure);
         $this->pendingMessage->shouldReceive('reissue')->andReturn($this->reissuer);
+        $this->pendingMessage->shouldReceive('webhook')->andReturn($this->webhook);
         $this->reissuer->shouldReceive('isReissuedNotification')->andReturn(false);
+        $this->webhook->shouldReceive('id')->andReturnNull();
 
         $this->assertEquals(
             [
@@ -49,6 +54,11 @@ class NotifiedEmbedsTest extends TestCase
                     'color' => Colour::NOTIFIED->value,
                     'description' => (new EventName($measure))->description(),
                     'fields' => [
+                        [
+                            'name' => 'Issued By',
+                            'value' => $measure->user->name,
+                            'inline' => false,
+                        ],
                         [
                             'name' => 'Minimum Departure Interval [MDI]',
                             'value' => '2 Minutes',
@@ -108,12 +118,89 @@ class NotifiedEmbedsTest extends TestCase
 
         $this->pendingMessage->shouldReceive('flowMeasure')->andReturn($measure);
         $this->pendingMessage->shouldReceive('reissue')->andReturn($this->reissuer);
+        $this->pendingMessage->shouldReceive('webhook')->andReturn($this->webhook);
         $this->reissuer->shouldReceive('isReissuedNotification')->andReturn(true);
+        $this->webhook->shouldReceive('id')->andReturnNull();
 
         $this->assertEquals(
             [
                 [
                     'title' => $measure->identifier . ' - ' . 'Notified (Reissued)',
+                    'color' => Colour::NOTIFIED->value,
+                    'description' => (new EventName($measure))->description(),
+                    'fields' => [
+                        [
+                            'name' => 'Issued By',
+                            'value' => $measure->user->name,
+                            'inline' => false,
+                        ],
+                        [
+                            'name' => 'Minimum Departure Interval [MDI]',
+                            'value' => '2 Minutes',
+                            'inline' => true,
+                        ],
+                        [
+                            'name' => 'Start Time',
+                            'value' => '22/05 1454Z',
+                            'inline' => true,
+                        ],
+                        [
+                            'name' => 'End Time',
+                            'value' => '1637Z',
+                            'inline' => true,
+                        ],
+                        [
+                            'name' => 'Departure Airports',
+                            'value' => 'EG\\*\\*',
+                            'inline' => true,
+                        ],
+                        [
+                            'name' => 'Arrival Airports',
+                            'value' => 'EHAM',
+                            'inline' => true,
+                        ],
+                        [
+                            'name' => "Applicable To FIR(s)",
+                            'value' => $fir->identifier,
+                            'inline' => true,
+                        ],
+                        [
+                            'name' => 'Level at or Below',
+                            'value' => '220',
+                            'inline' => false,
+                        ],
+                        [
+                            'name' => 'Reason',
+                            'value' => $measure->reason,
+                            'inline' => false,
+                        ],
+                    ],
+                ],
+            ],
+            $this->embeds->embeds()->toArray()
+        );
+    }
+
+    public function testItHasEmbedsWithoutIssuedByIfDivisionWebhook()
+    {
+        $measure = FlowMeasure::factory()
+            ->withTimes(Carbon::parse('2022-05-22T14:54:23Z'), Carbon::parse('2022-05-22T16:37:22Z'))
+            ->withEvent()
+            ->withAdditionalFilter(['type' => 'level_below', 'value' => 220])->create();
+
+        $fir = FlightInformationRegion::factory()->has(DiscordTag::factory()->count(2))->create();
+        $measure->notifiedFlightInformationRegions()->sync([$fir->id]);
+
+        $this->pendingMessage->shouldReceive('flowMeasure')->andReturn($measure);
+        $this->pendingMessage->shouldReceive('reissue')->andReturn($this->reissuer);
+        $this->pendingMessage->shouldReceive('webhook')->andReturn($this->webhook);
+        $this->reissuer->shouldReceive('isReissuedNotification')->andReturn(false);
+        $this->webhook->shouldReceive('id')->andReturn(1);
+
+        $this->assertEquals(
+            [
+                [
+                    'title' => $measure->identifier . ' - ' . 'Notified',
                     'color' => Colour::NOTIFIED->value,
                     'description' => (new EventName($measure))->description(),
                     'fields' => [

--- a/tests/Discord/FlowMeasure/Field/IssuingUserTest.php
+++ b/tests/Discord/FlowMeasure/Field/IssuingUserTest.php
@@ -25,6 +25,9 @@ class IssuingUserTest extends TestCase
 
     public function testItHasAValue()
     {
-        $this->assertEquals($this->flowMeasure->user->name, $this->issuingUser->value());
+        $this->assertEquals(
+            sprintf('%s (%d)', $this->flowMeasure->user->name, $this->flowMeasure->user->id),
+            $this->issuingUser->value()
+        );
     }
 }

--- a/tests/Discord/FlowMeasure/Field/IssuingUserTest.php
+++ b/tests/Discord/FlowMeasure/Field/IssuingUserTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Tests\Discord\FlowMeasure\Field;
+
+use App\Discord\FlowMeasure\Field\IssuingUser;
+use App\Models\FlowMeasure;
+use Tests\TestCase;
+
+class IssuingUserTest extends TestCase
+{
+    private readonly FlowMeasure $flowMeasure;
+    private readonly IssuingUser $issuingUser;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->flowMeasure = FlowMeasure::factory()->make();
+        $this->issuingUser = new IssuingUser($this->flowMeasure);
+    }
+
+    public function testItHasAName()
+    {
+        $this->assertEquals('Issued By', $this->issuingUser->name());
+    }
+
+    public function testItHasAValue()
+    {
+        $this->assertEquals($this->flowMeasure->user->name, $this->issuingUser->value());
+    }
+}

--- a/tests/Discord/Message/Embed/EmbedTest.php
+++ b/tests/Discord/Message/Embed/EmbedTest.php
@@ -86,6 +86,27 @@ class EmbedTest extends TestCase
         $this->assertEquals($expected, Embed::make()->withField($field1)->withField($field2)->toArray());
     }
 
+    public function testItSkipsFieldsByCondition()
+    {
+        $field1 = Mockery::mock(FieldInterface::class);
+        $field1->shouldReceive('name')->once()->andReturn('Field1');
+        $field1->shouldReceive('value')->once()->andReturn('Value1');
+        $field1->shouldReceive('inline')->once()->andReturn(true);
+        $field2 = Mockery::mock(FieldInterface::class);
+
+        $expected = [
+            'fields' => [
+                [
+                    'name' => 'Field1',
+                    'value' => 'Value1',
+                    'inline' => true,
+                ],
+            ],
+        ];
+
+        $this->assertEquals($expected, Embed::make()->withField($field1)->withField($field2, false)->toArray());
+    }
+
     public function testItHasFieldsByCollection()
     {
         $field1 = Mockery::mock(FieldInterface::class);


### PR DESCRIPTION
When sending activated and notified messages to ECFMP discord only, include the name and CID of who last issued the flow measure.

Field is omitted entirely for division webhooks.