### PR TITLE
fix: force conversion of TagInterface

### DIFF
--- a/app/Discord/FlowMeasure/Content/DivisionWebhookRecipients.php
+++ b/app/Discord/FlowMeasure/Content/DivisionWebhookRecipients.php
@@ -15,6 +15,6 @@ class DivisionWebhookRecipients implements FlowMeasureRecipientsInterface
 
     public function toString(): string
     {
-        return $this->tag;
+        return (string)$this->tag;
     }
 }

--- a/tests/Discord/FlowMeasure/Content/DivisionWebhookRecipientsTest.php
+++ b/tests/Discord/FlowMeasure/Content/DivisionWebhookRecipientsTest.php
@@ -11,7 +11,7 @@ class DivisionWebhookRecipientsTest extends TestCase
 {
     public function testItReturnsRecipients()
     {
-        $this->assertEquals(
+        $this->assertSame(
             '<@1234>',
             (new DivisionWebhookRecipients(new Tag(new DiscordTag(['tag' => '1234']))))->toString()
         );


### PR DESCRIPTION
Relates to:

```
App\Discord\FlowMeasure\Content\DivisionWebhookRecipients::toString(): Return value must be of type string, App\Discord\Message\Tag\Tag returned
```