### PR TITLE
feat: event participant details

### DIFF
--- a/app/Filament/Resources/EventResource.php
+++ b/app/Filament/Resources/EventResource.php
@@ -90,7 +90,11 @@ class EventResource extends Resource
                 Forms\Components\TagsInput::make('participants.cid')
                     ->label(__('Participant CIDs'))
                     ->columnSpan('full')
-                    ->afterStateHydrated(function (Event $record, Forms\Components\TagsInput $component) {
+                    ->afterStateHydrated(function (?Event $record, Forms\Components\TagsInput $component) {
+                        if (is_null($record)) {
+                            return;
+                        }
+
                         $component->state($record->participants->pluck('cid'));
                     })
                     ->disabled()

--- a/app/Filament/Resources/EventResource.php
+++ b/app/Filament/Resources/EventResource.php
@@ -98,7 +98,7 @@ class EventResource extends Resource
                         $component->state($record->participants->pluck('cid'));
                     })
                     ->disabled()
-                    ->visible(fn(Page $livewire, $state) => $livewire instanceof ViewRecord && in_array(auth()->user()->role->key, [
+                    ->visible(fn (Page $livewire, $state) => $livewire instanceof ViewRecord && in_array(auth()->user()->role->key, [
                             RoleKey::SYSTEM,
                             RoleKey::NMT,
                             RoleKey::FLOW_MANAGER,

--- a/app/Http/Resources/EventResource.php
+++ b/app/Http/Resources/EventResource.php
@@ -23,7 +23,7 @@ class EventResource extends JsonResource
             'date_end' => ApiDateTimeFormatter::formatDateTime($this->date_end),
             'flight_information_region_id' => $this->flight_information_region_id,
             'vatcan_code' => $this->vatcan_code,
-            'participants' => $this->participants->map(fn(EventParticipant $eventParticipant) => [
+            'participants' => $this->participants->map(fn (EventParticipant $eventParticipant) => [
                 'cid' => $eventParticipant->cid,
                 'destination' => $eventParticipant->destination,
                 'origin' => $eventParticipant->origin,

--- a/app/Http/Resources/EventResource.php
+++ b/app/Http/Resources/EventResource.php
@@ -3,6 +3,7 @@
 namespace App\Http\Resources;
 
 use App\Helpers\ApiDateTimeFormatter;
+use App\Models\EventParticipant;
 use Illuminate\Http\Resources\Json\JsonResource;
 
 class EventResource extends JsonResource
@@ -22,7 +23,11 @@ class EventResource extends JsonResource
             'date_end' => ApiDateTimeFormatter::formatDateTime($this->date_end),
             'flight_information_region_id' => $this->flight_information_region_id,
             'vatcan_code' => $this->vatcan_code,
-            'participants' => $this->participants,
+            'participants' => $this->participants->map(fn(EventParticipant $eventParticipant) => [
+                'cid' => $eventParticipant->cid,
+                'destination' => $eventParticipant->destination,
+                'origin' => $eventParticipant->origin,
+            ]),
         ];
     }
 }

--- a/app/Imports/EventParticipantsImport.php
+++ b/app/Imports/EventParticipantsImport.php
@@ -40,8 +40,8 @@ class EventParticipantsImport implements ToCollection, WithEvents
         $this->event->participants()->delete();
         $this->event->participants()->createMany(
             $rows
-                ->filter(fn($row) => $this->rowValid($row))
-                ->map(fn(Collection $row): array => [
+                ->filter(fn ($row) => $this->rowValid($row))
+                ->map(fn (Collection $row): array => [
                     'cid' => $row[0],
                     'origin' => empty($row[1]) ? null : Str::upper($row[1]),
                     'destination' => empty($row[2]) ? null : Str::upper($row[2]),

--- a/app/Imports/EventParticipantsImport.php
+++ b/app/Imports/EventParticipantsImport.php
@@ -40,11 +40,11 @@ class EventParticipantsImport implements ToCollection, WithEvents
         $this->event->participants()->delete();
         $this->event->participants()->createMany(
             $rows
-                ->filter(fn ($row) => $this->rowValid($row))
-                ->map(fn (Collection $row): array => [
+                ->filter(fn($row) => $this->rowValid($row))
+                ->map(fn(Collection $row): array => [
                     'cid' => $row[0],
-                    'origin' => empty($row[1]) ? null : Str::upper($row[1]),
-                    'destination' => empty($row[2]) ? null : Str::upper($row[2]),
+                    'origin' => !isset($row[1]) || empty($row[1]) ? null : Str::upper($row[1]),
+                    'destination' => !isset($row[2]) || empty($row[2]) ? null : Str::upper($row[2]),
                 ])
                 ->values()
         );
@@ -53,8 +53,8 @@ class EventParticipantsImport implements ToCollection, WithEvents
     private function rowValid(Collection $row): bool
     {
         return $this->hasValidCid($row[0]) &&
-            $this->hasValidAirfield($row[1]) &&
-            $this->hasValidAirfield($row[2]);
+            $this->hasValidAirfield($row[1] ?? null) &&
+            $this->hasValidAirfield($row[2] ?? null);
     }
 
     private function hasValidCid($cid): bool

--- a/app/Imports/EventParticipantsImport.php
+++ b/app/Imports/EventParticipantsImport.php
@@ -5,6 +5,7 @@ namespace App\Imports;
 use App\Models\Event;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
 use Maatwebsite\Excel\Events\AfterSheet;
 use Maatwebsite\Excel\Concerns\Importable;
 use Maatwebsite\Excel\Concerns\WithEvents;
@@ -27,6 +28,8 @@ class EventParticipantsImport implements ToCollection, WithEvents
     // The minimum "normal" CID
     private const MINIMUM_MEMBER_CID = 810000;
 
+    private const AIRFIELD_ICAO_REGEX = '/[A-Za-z]{4}/';
+
     public function __construct(public Event $event, public string $filePath)
     {
         //
@@ -34,21 +37,40 @@ class EventParticipantsImport implements ToCollection, WithEvents
 
     public function collection(Collection $rows)
     {
-        $cids = $rows
-            ->flatten()
-            ->filter(fn ($row) => $this->hasValidCid($row))
-            ->values();
-
-        $this->event->update([
-            'participants' => $cids,
-        ]);
+        $this->event->participants()->delete();
+        $this->event->participants()->createMany(
+            $rows
+                ->filter(fn($row) => $this->rowValid($row))
+                ->map(fn(Collection $row): array => [
+                    'cid' => $row[0],
+                    'origin' => empty($row[1]) ? null : Str::upper($row[1]),
+                    'destination' => empty($row[2]) ? null : Str::upper($row[2]),
+                ])
+                ->values()
+        );
     }
 
-    private function hasValidCid($cid)
+    private function rowValid(Collection $row): bool
     {
-        $cid = (int) $cid;
+        return $this->hasValidCid($row[0]) &&
+            $this->hasValidAirfield($row[1]) &&
+            $this->hasValidAirfield($row[2]);
+    }
+
+    private function hasValidCid($cid): bool
+    {
+        if (!is_int($cid)) {
+            return false;
+        }
+
+        $cid = (int)$cid;
         return $cid >= self::MINIMUM_MEMBER_CID ||
             ($cid >= self::MINIMUM_CID && $cid <= self::MAXIMUM_FOUNDER_CID);
+    }
+
+    private function hasValidAirfield($airfield): bool
+    {
+        return empty($airfield) || preg_match(self::AIRFIELD_ICAO_REGEX, (string)$airfield) === 1;
     }
 
     public static function afterSheet(AfterSheet $event)

--- a/app/Models/Event.php
+++ b/app/Models/Event.php
@@ -54,7 +54,12 @@ class Event extends Model
     protected function nameDate(): Attribute
     {
         return new Attribute(
-            fn () => "{$this->name} [{$this->date_start->format('M j, Y')}]",
+            fn() => "{$this->name} [{$this->date_start->format('M j, Y')}]",
         );
+    }
+
+    public function eventParticipants(): HasMany
+    {
+        return $this->hasMany(EventParticipant::class);
     }
 }

--- a/app/Models/Event.php
+++ b/app/Models/Event.php
@@ -21,17 +21,12 @@ class Event extends Model
         'date_start',
         'date_end',
         'flight_information_region_id',
-        'vatcan_code',
-        'participants',
+        'vatcan_code'
     ];
 
     protected $dates = [
         'date_start',
         'date_end',
-    ];
-
-    protected $casts = [
-        'participants' => 'array',
     ];
 
     public function flightInformationRegion(): BelongsTo
@@ -58,7 +53,7 @@ class Event extends Model
         );
     }
 
-    public function eventParticipants(): HasMany
+    public function participants(): HasMany
     {
         return $this->hasMany(EventParticipant::class);
     }

--- a/app/Models/Event.php
+++ b/app/Models/Event.php
@@ -49,7 +49,7 @@ class Event extends Model
     protected function nameDate(): Attribute
     {
         return new Attribute(
-            fn() => "{$this->name} [{$this->date_start->format('M j, Y')}]",
+            fn () => "{$this->name} [{$this->date_start->format('M j, Y')}]",
         );
     }
 

--- a/app/Models/EventParticipant.php
+++ b/app/Models/EventParticipant.php
@@ -2,11 +2,15 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
 class EventParticipant extends Model
 {
+    use HasFactory;
+
     protected $fillable = [
+        'event_id',
         'cid',
         'origin',
         'destination',

--- a/app/Models/EventParticipant.php
+++ b/app/Models/EventParticipant.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class EventParticipant extends Model
+{
+    protected $fillable = [
+        'cid',
+        'origin',
+        'destination',
+    ];
+
+    public $timestamps = false;
+}

--- a/database/factories/EventFactory.php
+++ b/database/factories/EventFactory.php
@@ -2,6 +2,7 @@
 
 namespace Database\Factories;
 
+use App\Models\EventParticipant;
 use App\Models\FlightInformationRegion;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
@@ -44,13 +45,6 @@ class EventFactory extends Factory
 
     public function withParticipants(): static
     {
-        return $this->state(function () {
-            $participants = [];
-            for ($i = 0; $i < $this->faker->numberBetween(1, 8); $i++) {
-                $participants[] = $this->faker->unique()->numberBetween(900000, 1600000);
-            }
-
-            return ['participants' => $participants];
-        });
+        return $this->has(EventParticipant::factory()->count($this->faker->numberBetween(1, 8)), 'participants');
     }
 }

--- a/database/factories/EventFactory.php
+++ b/database/factories/EventFactory.php
@@ -16,7 +16,6 @@ class EventFactory extends Factory
             'date_end' => $this->faker->dateTimeBetween('+1 hour', '+2 hour'),
             'flight_information_region_id' => FlightInformationRegion::factory()->create()->id,
             'vatcan_code' => null,
-            'participants' => null,
         ];
     }
 

--- a/database/factories/EventParticipantFactory.php
+++ b/database/factories/EventParticipantFactory.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\EventParticipant;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Str;
+
+class EventParticipantFactory extends Factory
+{
+    protected $model = EventParticipant::class;
+
+    public function definition(): array
+    {
+        return [
+            'cid' => $this->faker->unique()->numberBetween(900000, 1600000),
+            'origin' => Str::upper($this->faker->unique()->lexify()),
+            'destination' => Str::upper($this->faker->unique()->lexify()),
+        ];
+    }
+}

--- a/database/migrations/2022_07_26_200013_create_event_participants_table.php
+++ b/database/migrations/2022_07_26_200013_create_event_participants_table.php
@@ -5,8 +5,7 @@ use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 use App\Models\Event;
 
-return new class extends Migration
-{
+return new class () extends Migration {
     /**
      * Run the migrations.
      *

--- a/database/migrations/2022_07_26_200013_create_event_participants_table.php
+++ b/database/migrations/2022_07_26_200013_create_event_participants_table.php
@@ -1,0 +1,41 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use App\Models\Event;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('event_participants', function (Blueprint $table) {
+            $table->id();
+            $table->foreignIdFor(Event::class);
+            $table->unsignedBigInteger('cid');
+            $table->string('origin', 4)->nullable();
+            $table->string('destination', 4)->nullable();
+
+            $table->unique(['event_id', 'cid']);
+            $table->foreign('event_id')
+                ->references('id')
+                ->on('events')
+                ->cascadeOnDelete();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('event_participants');
+    }
+};

--- a/database/migrations/2022_07_26_200013_create_event_participants_table.php
+++ b/database/migrations/2022_07_26_200013_create_event_participants_table.php
@@ -21,7 +21,6 @@ return new class extends Migration
             $table->string('origin', 4)->nullable();
             $table->string('destination', 4)->nullable();
 
-            $table->unique(['event_id', 'cid']);
             $table->foreign('event_id')
                 ->references('id')
                 ->on('events')

--- a/database/migrations/2022_07_28_184847_drop_event_participants_column.php
+++ b/database/migrations/2022_07_28_184847_drop_event_participants_column.php
@@ -4,8 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class extends Migration
-{
+return new class () extends Migration {
     /**
      * Run the migrations.
      *

--- a/database/migrations/2022_07_28_184847_drop_event_participants_column.php
+++ b/database/migrations/2022_07_28_184847_drop_event_participants_column.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('events', function (Blueprint $table) {
+            $table->dropColumn('participants');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        //
+    }
+};

--- a/spec/api-spec-v1.json
+++ b/spec/api-spec-v1.json
@@ -1,957 +1,979 @@
 {
-  "openapi": "3.0.2",
-  "info": {
-    "title": "Flow API",
-    "description": "API for European Collaboration and Flow Management Project (ECFMP) flow measures.",
-    "termsOfService": "https://vatsim.net",
-    "contact": {
-      "email": "k.hardern@vatsim.net"
-    },
-    "license": {
-      "name": "GPL-3.0-only",
-      "url": "https://www.gnu.org/licenses/gpl-3.0.en.html"
-    },
-    "version": "v1"
-  },
-  "servers": [
-    {
-      "url": "https://ecfmp.vatsim.net/api/v1"
-    }
-  ],
-  "tags": [
-    {
-      "name": "Airport Groups",
-      "description": "Relates to groups of airports, such as TMAs."
-    },
-    {
-      "name": "Documentation",
-      "description": "Produces an OpenAPI JSON specification for a given version of the API."
-    },
-    {
-      "name": "Events",
-      "description": "Relates to organised network events that may incur higher-than-normal traffic loads."
-    },
-    {
-      "name": "Flow Measures",
-      "description": "Relates to flow measures put in place to control traffic flow on the VATSIM network."
-    },
-    {
-      "name": "Flight Information Regions",
-      "description": "Relates to flight information regions"
-    },
-    {
-      "name": "Plugins",
-      "description": "Non-RESTful APIs that plugins can use for easy access to data"
-    }
-  ],
-  "paths": {
-    "/docs/v{number}": {
-      "get": {
-        "tags": [
-          "Documentation"
-        ],
-        "summary": "Get a specification of the version documentation",
-        "description": "GET /docs/v{number}/",
-        "operationId": "getDocs",
-        "parameters": [
-          {
-            "name": "number",
-            "in": "path",
-            "description": "Version of the documentation to request",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "format": "int64"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful operation",
-            "content": {
-              "application/json": {
-              }
-            }
-          },
-          "404": {
-            "description": "Documentation version not found"
-          }
+    "openapi": "3.0.2",
+    "info": {
+        "title": "Flow API",
+        "description": "API for European Collaboration and Flow Management Project (ECFMP) flow measures.",
+        "termsOfService": "https://vatsim.net",
+        "contact": {
+            "email": "k.hardern@vatsim.net"
         },
-        "security": [
-        ]
-      }
-    },
-    "/airport-group": {
-      "get": {
-        "tags": [
-          "Airport Groups"
-        ],
-        "summary": "Get all airport groups",
-        "description": "GET /airport-group",
-        "operationId": "getAirportGroups",
-        "responses": {
-          "200": {
-            "description": "Successful operation",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AirportGroups"
-                }
-              }
-            }
-          }
+        "license": {
+            "name": "GPL-3.0-only",
+            "url": "https://www.gnu.org/licenses/gpl-3.0.en.html"
         },
-        "security": [
-        ]
-      }
+        "version": "v1"
     },
-    "/airport-group/{id}": {
-      "get": {
-        "tags": [
-          "Airport Groups"
-        ],
-        "summary": "Get an airport group by id",
-        "description": "GET /airport-group/{id}",
-        "operationId": "getAirportGroup",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "description": "Unique ID of the airport group",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "format": "int64"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful operation",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AirportGroup"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Airport group not found"
-          }
-        },
-        "security": [
-        ]
-      }
-    },
-    "/event": {
-      "get": {
-        "tags": [
-          "Events"
-        ],
-        "summary": "Get all events",
-        "description": "GET /event",
-        "operationId": "getEvents",
-        "parameters": [
-          {
-            "name": "active",
-            "in": "query",
-            "description": "Only return active events",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "format": "int64",
-              "example": 1
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful operation",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Events"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-        ]
-      }
-    },
-    "/event/{id}": {
-      "get": {
-        "tags": [
-          "Events"
-        ],
-        "summary": "Get a single event by id",
-        "description": "GET /event/{id}",
-        "operationId": "getEvent",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "description": "Unique ID of the event",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "format": "int64"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful operation",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Event"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Event not found"
-          }
-        },
-        "security": [
-        ]
-      }
-    },
-    "/flight-information-region": {
-      "get": {
-        "tags": [
-          "Flight Information Regions"
-        ],
-        "summary": "Get all flight information regions",
-        "description": "GET /flight-information-region",
-        "operationId": "getFlightInformationRegions",
-        "responses": {
-          "200": {
-            "description": "Successful operation",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/FlightInformationRegions"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-        ]
-      }
-    },
-    "/flight-information-region/{id}": {
-      "get": {
-        "tags": [
-          "Flight Information Regions"
-        ],
-        "summary": "Get a single flight information region by id",
-        "description": "GET /flight-information-region/{id}",
-        "operationId": "getFlightInformationRegion",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "description": "Unique ID of the flight information region",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "format": "int64"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful operation",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/FlightInformationRegion"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Flight information region not found"
-          }
-        },
-        "security": [
-        ]
-      }
-    },
-    "/flow-measure": {
-      "get": {
-        "tags": [
-          "Flow Measures"
-        ],
-        "summary": "Get all flow measures",
-        "description": "GET /flow-measure",
-        "operationId": "getFlowMeasures",
-        "parameters": [
-          {
-            "in": "query",
-            "name": "deleted",
-            "schema": {
-              "type": "integer",
-              "example": 1
-            },
-            "required": false,
-            "description": "Include deleted flow measures"
-          },
-          {
-            "in": "query",
-            "name": "active",
-            "schema": {
-              "type": "integer",
-              "example": 1
-            },
-            "required": false,
-            "description": "Only include flow measures that are currently active, can be used in combination with notified"
-          },
-          {
-            "in": "query",
-            "name": "notified",
-            "schema": {
-              "type": "integer",
-              "example": 1
-            },
-            "required": false,
-            "description": "Only include flow measures that are currently notified, can be used in combination with active"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful operation",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/FlowMeasures"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-        ]
-      }
-    },
-    "/flow-measure/{id}": {
-      "get": {
-        "tags": [
-          "Flow Measures"
-        ],
-        "summary": "Get a single flow measure by id",
-        "description": "GET /flow-measure/{id}",
-        "operationId": "getFlowMeasure",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "description": "Unique ID of the flow measure",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "format": "int64"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful operation",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/FlowMeasure"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Flow measure not found"
-          }
-        },
-        "security": [
-        ]
-      }
-    },
-    "/plugin": {
-      "get": {
-        "tags": [
-          "Plugins"
-        ],
-        "summary": "A combined set of data for easy access by controller client plugins. Flow measures include only notified, active and recently finished.",
-        "description": "GET /plugin",
-        "operationId": "getPluginData",
-        "responses": {
-          "200": {
-            "description": "Successful operation",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Plugin"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-        ]
-      }
-    }
-  },
-  "components": {
-    "schemas": {
-      "AirportGroup": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "integer",
-            "format": "int64",
-            "example": 10,
-            "description": "System id"
-          },
-          "name": {
-            "type": "string",
-            "description": "Name of the airport group",
-            "example": "London TMA Group"
-          },
-          "airports": {
-            "type": "array",
-            "description": "List of airport ICAO codes",
-            "items": {
-              "type": "string",
-              "format": "Airport ICAO code",
-              "example": "EGLL"
-            },
-            "example": [
-              "EGLL",
-              "EGKK",
-              "EGLC"
-            ]
-          }
+    "servers": [
+        {
+            "url": "https://ecfmp.vatsim.net/api/v1"
         }
-      },
-      "AirportGroups": {
-        "type": "array",
-        "items": {
-          "$ref": "#/components/schemas/AirportGroup"
+    ],
+    "tags": [
+        {
+            "name": "Airport Groups",
+            "description": "Relates to groups of airports, such as TMAs."
+        },
+        {
+            "name": "Documentation",
+            "description": "Produces an OpenAPI JSON specification for a given version of the API."
+        },
+        {
+            "name": "Events",
+            "description": "Relates to organised network events that may incur higher-than-normal traffic loads."
+        },
+        {
+            "name": "Flow Measures",
+            "description": "Relates to flow measures put in place to control traffic flow on the VATSIM network."
+        },
+        {
+            "name": "Flight Information Regions",
+            "description": "Relates to flight information regions"
+        },
+        {
+            "name": "Plugins",
+            "description": "Non-RESTful APIs that plugins can use for easy access to data"
         }
-      },
-      "Event": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "integer",
-            "format": "int64",
-            "example": 10,
-            "description": "System id"
-          },
-          "name": {
-            "type": "string",
-            "example": "Heathrow Overload",
-            "description": "Name of the event"
-          },
-          "date_start": {
-            "type": "string",
-            "format": "datetime",
-            "example": "2022-04-18T13:15:30Z",
-            "description": "The start time of the event, will always be Z"
-          },
-          "date_end": {
-            "type": "string",
-            "format": "datetime",
-            "example": "2022-04-18T13:15:30Z",
-            "description": "The end time of the event, will always be Z"
-          },
-          "flight_information_region_id": {
-            "type": "integer",
-            "format": "int64",
-            "example": 1,
-            "description": "The flight information region where this event is taking place"
-          },
-          "vatcan_code": {
-            "type": "string",
-            "format": "VATCAN event code",
-            "nullable": true,
-            "example": "abcd",
-            "description": "The VATCAN booking code associated with this event, if present"
-          },
-          "participants": {
-            "type": "array",
-            "items": {
-              "type": "integer",
-              "description": "A VATSIM CID",
-              "example": 1203533
-            },
-            "nullable": true,
-            "example": [
-              1203533,
-              1521312
-            ],
-            "description": "Array of VATSIM CIDs participating in the event"
-          }
-        }
-      },
-      "Events": {
-        "type": "array",
-        "items": {
-          "$ref": "#/components/schemas/Event"
-        }
-      },
-      "FlightInformationRegion": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "integer",
-            "format": "int64",
-            "example": 10,
-            "description": "System id"
-          },
-          "identifier": {
-            "type": "string",
-            "format": "ICAO code",
-            "example": "EGTT",
-            "minLength": 4,
-            "maxLength": 4,
-            "description": "The ICAO identifier for the FIR"
-          },
-          "name": {
-            "type": "string",
-            "example": "London",
-            "description": "Other name for the FIR"
-          }
-        }
-      },
-      "FlightInformationRegions": {
-        "type": "array",
-        "items": {
-          "$ref": "#/components/schemas/FlightInformationRegion"
-        }
-      },
-      "FlowMeasures": {
-        "type": "array",
-        "items": {
-          "$ref": "#/components/schemas/FlowMeasure"
-        }
-      },
-      "FlowMeasure": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "integer",
-            "format": "int64",
-            "example": 10,
-            "description": "System id."
-          },
-          "ident": {
-            "type": "string",
-            "description": "Automatically assigned identifier for this flow measure - FIR, day of month, designator.",
-            "example": "EGTT25B"
-          },
-          "event_id": {
-            "type": "integer",
-            "format": "int64",
-            "description": "The identifier of the event for this flow measure",
-            "example": 44
-          },
-          "reason": {
-            "type": "string",
-            "description": "Why this flow measure is being enforced",
-            "example": "Due runway capacity"
-          },
-          "starttime": {
-            "type": "string",
-            "format": "datetime",
-            "example": "2022-04-18T13:15:30Z"
-          },
-          "endtime": {
-            "type": "string",
-            "format": "datetime",
-            "example": "2022-04-18T13:15:30Z"
-          },
-          "notified_flight_information_regions": {
-            "type": "array",
-            "description": "An array of flight information ids that are to be notified of this flow measure",
-            "example": [1, 2, 42],
-            "items": {
-              "type": "integer",
-              "example": 5,
-              "description": "The system id of a flight information region"
-            }
-          },
-          "measure": {
-            "oneOf": [
-              {
-                "type": "object",
-                "properties": {
-                  "type": {
-                    "type": "string",
-                    "enum": [
-                      "minimum_departure_interval",
-                      "average_departure_interval"
-                    ]
-                  },
-                  "value": {
-                    "type": "integer",
-                    "format": "int64",
-                    "description": "The number of seconds applicable to this measure",
-                    "example": 120
-                  }
-                }
-              },
-              {
-                "type": "object",
-                "properties": {
-                  "type": {
-                    "type": "string",
-                    "enum": [
-                      "per_hour"
-                    ]
-                  },
-                  "value": {
-                    "type": "integer",
-                    "format": "int64",
-                    "description": "The number of flights per hour permitted",
-                    "example": 5
-                  }
-                }
-              },
-              {
-                "type": "object",
-                "properties": {
-                  "type": {
-                    "type": "string",
-                    "enum": [
-                      "miles_in_trail"
-                    ]
-                  },
-                  "value": {
-                    "type": "integer",
-                    "format": "int64",
-                    "description": "The distance in nm of aircraft in trail",
-                    "example": 5
-                  }
-                }
-              },
-              {
-                "type": "object",
-                "properties": {
-                  "type": {
-                    "type": "string",
-                    "enum": [
-                      "max_ias"
-                    ]
-                  },
-                  "value": {
-                    "type": "integer",
-                    "format": "int64",
-                    "description": "The maximum allowable indicated airspeed",
-                    "example": 275
-                  }
-                }
-              },
-              {
-                "type": "object",
-                "properties": {
-                  "type": {
-                    "type": "string",
-                    "enum": [
-                      "max_mach"
-                    ]
-                  },
-                  "value": {
-                    "type": "integer",
-                    "format": "int64",
-                    "description": "The maximum allowable mach number",
-                    "example": "82 = 0.82 Mach"
-                  }
-                }
-              },
-              {
-                "type": "object",
-                "properties": {
-                  "type": {
-                    "type": "string",
-                    "enum": [
-                      "ias_reduction"
-                    ]
-                  },
-                  "value": {
-                    "type": "integer",
-                    "format": "int64",
-                    "description": "How much to reduce indicated airspeed by",
-                    "example": "50"
-                  }
-                }
-              },
-              {
-                "type": "object",
-                "properties": {
-                  "type": {
-                    "type": "string",
-                    "enum": [
-                      "mach_reduction"
-                    ]
-                  },
-                  "value": {
-                    "type": "integer",
-                    "format": "int64",
-                    "description": "How much to reduce mach number by",
-                    "example": "5 = 0.05 Mach"
-                  }
-                }
-              },
-              {
-                "type": "object",
-                "properties": {
-                  "type": {
-                    "type": "string",
-                    "enum": [
-                      "prohibit"
-                    ],
-                    "description": "Prohibit a flight according to given filters"
-                  },
-                  "value": {
-                    "type": "null"
-                  }
-                }
-              },
-              {
-                "type": "object",
-                "properties": {
-                  "type": {
-                    "type": "string",
-                    "enum": [
-                      "ground_stop"
-                    ],
-                    "description": "No departures are permitted"
-                  },
-                  "value": {
-                    "type": "null"
-                  }
-                }
-              },
-              {
-                "type": "object",
-                "properties": {
-                  "type": {
-                    "type": "string",
-                    "enum": [
-                      "mandatory_route"
-                    ]
-                  },
-                  "value": {
-                    "type": "array",
-                    "items": {
-                      "type": "string",
-                      "format": "JSON",
-                      "description": "The specified mandatory route string",
-                      "example": "UL612 LAKEY DCT NUGRA"
-                    },
-                    "format": "JSON",
-                    "description": "Ar array of mandatory route strings, items are related via logical OR",
-                    "example": ["LOGAN", "UL612 LAKEY DCT NUGRA"]
-                  }
-                }
-              }
-            ]
-          },
-          "filters": {
-            "type": "array",
-            "format": "JSON",
-            "description": "The applicable filters for this flow measure. Multiple filters are joined by logical AND.",
-            "minItems": 2,
-            "items": {
-              "anyOf": [
-                {
-                  "type": "object",
-                  "properties": {
-                    "type": {
-                      "type": "string",
-                      "enum": [
-                        "ADEP"
-                      ]
-                    },
-                    "value": {
-                      "type": "array",
-                      "minItems": 1,
-                      "description": "The departure airfields. Can be wildcarded with *. This filter is mandatory.",
-                      "items": {
-                        "type": "string"
-                      },
-                      "example": [
-                        "EGKK",
-                        "EGLL"
-                      ]
-                    }
-                  }
-                },
-                {
-                  "type": "object",
-                  "properties": {
-                    "type": {
-                      "type": "string",
-                      "enum": [
-                        "ADES"
-                      ]
-                    },
-                    "value": {
-                      "description": "The departure airfields. Can be wildcarded with *. This filter is mandatory.",
-                      "type": "array",
-                      "minItems": 1,
-                      "items": {
-                        "type": "string"
-                      },
-                      "example": [
-                        "EH**"
-                      ]
-                    }
-                  }
-                },
-                {
-                  "type": "object",
-                  "properties": {
-                    "type": {
-                      "type": "string",
-                      "enum": [
-                        "level_above",
-                        "level_below"
-                      ]
-                    },
-                    "value": {
-                      "description": "Three digit flight level. Values are inclusive.",
-                      "type": "integer",
-                      "example": 350
-                    }
-                  }
-                },
-                {
-                  "type": "object",
-                  "properties": {
-                    "type": {
-                      "type": "string",
-                      "enum": [
-                        "level"
-                      ]
-                    },
-                    "value": {
-                      "description": "List of three digit flight levels.",
-                      "type": "array",
-                      "minItems": 1,
-                      "items": {
-                        "type": "integer"
-                      },
-                      "example": [
-                        360,
-                        370,
-                        380
-                      ]
-                    }
-                  }
-                },
-                {
-                  "type": "object",
-                  "properties": {
-                    "type": {
-                      "type": "string",
-                      "enum": [
-                        "member_event",
-                        "member_not_event"
-                      ]
-                    },
-                    "value": {
-                      "type": "array",
-                      "items": {
-                        "type": "object",
-                        "properties": {
-                          "event_id": {
+    ],
+    "paths": {
+        "/docs/v{number}": {
+            "get": {
+                "tags": [
+                    "Documentation"
+                ],
+                "summary": "Get a specification of the version documentation",
+                "description": "GET /docs/v{number}/",
+                "operationId": "getDocs",
+                "parameters": [
+                    {
+                        "name": "number",
+                        "in": "path",
+                        "description": "Version of the documentation to request",
+                        "required": true,
+                        "schema": {
                             "type": "integer",
-                            "example": 1,
-                            "description": "The id of the event in the API"
-                          },
-                          "event_vatcan": {
-                            "type": "string",
-                            "nullable": true,
-                            "description": "The events VATCAN code",
-                            "example": "ABCD01"
-                          },
-                          "event_api": {
-                            "type": "null",
-                            "description": "The events API code",
-                            "example": null
-                          }
+                            "format": "int64"
                         }
-                      }
                     }
-                  }
-                },
-                {
-                  "type": "object",
-                  "properties": {
-                    "type": {
-                      "type": "string",
-                      "enum": [
-                        "waypoint"
-                      ]
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "content": {
+                            "application/json": {
+                            }
+                        }
                     },
-                    "value": {
-                      "type": "array",
-                      "items": {
-                        "description": "String of waypoints",
-                        "type": "string",
-                        "format": "JSON",
-                        "example": "BIG UL9 CPT"
-                      },
-                      "description": "List of waypoint / route strings, joined via logical OR"
+                    "404": {
+                        "description": "Documentation version not found"
                     }
-                  }
+                },
+                "security": [
+                ]
+            }
+        },
+        "/airport-group": {
+            "get": {
+                "tags": [
+                    "Airport Groups"
+                ],
+                "summary": "Get all airport groups",
+                "description": "GET /airport-group",
+                "operationId": "getAirportGroups",
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/AirportGroups"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                ]
+            }
+        },
+        "/airport-group/{id}": {
+            "get": {
+                "tags": [
+                    "Airport Groups"
+                ],
+                "summary": "Get an airport group by id",
+                "description": "GET /airport-group/{id}",
+                "operationId": "getAirportGroup",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "Unique ID of the airport group",
+                        "required": true,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int64"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/AirportGroup"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Airport group not found"
+                    }
+                },
+                "security": [
+                ]
+            }
+        },
+        "/event": {
+            "get": {
+                "tags": [
+                    "Events"
+                ],
+                "summary": "Get all events",
+                "description": "GET /event",
+                "operationId": "getEvents",
+                "parameters": [
+                    {
+                        "name": "active",
+                        "in": "query",
+                        "description": "Only return active events",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int64",
+                            "example": 1
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Events"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                ]
+            }
+        },
+        "/event/{id}": {
+            "get": {
+                "tags": [
+                    "Events"
+                ],
+                "summary": "Get a single event by id",
+                "description": "GET /event/{id}",
+                "operationId": "getEvent",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "Unique ID of the event",
+                        "required": true,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int64"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Event"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Event not found"
+                    }
+                },
+                "security": [
+                ]
+            }
+        },
+        "/flight-information-region": {
+            "get": {
+                "tags": [
+                    "Flight Information Regions"
+                ],
+                "summary": "Get all flight information regions",
+                "description": "GET /flight-information-region",
+                "operationId": "getFlightInformationRegions",
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/FlightInformationRegions"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                ]
+            }
+        },
+        "/flight-information-region/{id}": {
+            "get": {
+                "tags": [
+                    "Flight Information Regions"
+                ],
+                "summary": "Get a single flight information region by id",
+                "description": "GET /flight-information-region/{id}",
+                "operationId": "getFlightInformationRegion",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "Unique ID of the flight information region",
+                        "required": true,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int64"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/FlightInformationRegion"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Flight information region not found"
+                    }
+                },
+                "security": [
+                ]
+            }
+        },
+        "/flow-measure": {
+            "get": {
+                "tags": [
+                    "Flow Measures"
+                ],
+                "summary": "Get all flow measures",
+                "description": "GET /flow-measure",
+                "operationId": "getFlowMeasures",
+                "parameters": [
+                    {
+                        "in": "query",
+                        "name": "deleted",
+                        "schema": {
+                            "type": "integer",
+                            "example": 1
+                        },
+                        "required": false,
+                        "description": "Include deleted flow measures"
+                    },
+                    {
+                        "in": "query",
+                        "name": "active",
+                        "schema": {
+                            "type": "integer",
+                            "example": 1
+                        },
+                        "required": false,
+                        "description": "Only include flow measures that are currently active, can be used in combination with notified"
+                    },
+                    {
+                        "in": "query",
+                        "name": "notified",
+                        "schema": {
+                            "type": "integer",
+                            "example": 1
+                        },
+                        "required": false,
+                        "description": "Only include flow measures that are currently notified, can be used in combination with active"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/FlowMeasures"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                ]
+            }
+        },
+        "/flow-measure/{id}": {
+            "get": {
+                "tags": [
+                    "Flow Measures"
+                ],
+                "summary": "Get a single flow measure by id",
+                "description": "GET /flow-measure/{id}",
+                "operationId": "getFlowMeasure",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "Unique ID of the flow measure",
+                        "required": true,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int64"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/FlowMeasure"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Flow measure not found"
+                    }
+                },
+                "security": [
+                ]
+            }
+        },
+        "/plugin": {
+            "get": {
+                "tags": [
+                    "Plugins"
+                ],
+                "summary": "A combined set of data for easy access by controller client plugins. Flow measures include only notified, active and recently finished.",
+                "description": "GET /plugin",
+                "operationId": "getPluginData",
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Plugin"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                ]
+            }
+        }
+    },
+    "components": {
+        "schemas": {
+            "AirportGroup": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "integer",
+                        "format": "int64",
+                        "example": 10,
+                        "description": "System id"
+                    },
+                    "name": {
+                        "type": "string",
+                        "description": "Name of the airport group",
+                        "example": "London TMA Group"
+                    },
+                    "airports": {
+                        "type": "array",
+                        "description": "List of airport ICAO codes",
+                        "items": {
+                            "type": "string",
+                            "format": "Airport ICAO code",
+                            "example": "EGLL"
+                        },
+                        "example": [
+                            "EGLL",
+                            "EGKK",
+                            "EGLC"
+                        ]
+                    }
                 }
-              ]
             },
-            "example": [
-              {
-                "type": "ADEP",
-                "value": [
-                  "EGKK",
-                  "EGLL",
-                  "EGSS"
-                ]
-              },
-              {
-                "type": "ADES",
-                "value": [
-                  "EH**"
-                ]
-              },
-              {
-                "type": "level",
-                "value": [
-                  230,
-                  240
-                ]
-              }
-            ]
-          }
+            "AirportGroups": {
+                "type": "array",
+                "items": {
+                    "$ref": "#/components/schemas/AirportGroup"
+                }
+            },
+            "Event": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "integer",
+                        "format": "int64",
+                        "example": 10,
+                        "description": "System id"
+                    },
+                    "name": {
+                        "type": "string",
+                        "example": "Heathrow Overload",
+                        "description": "Name of the event"
+                    },
+                    "date_start": {
+                        "type": "string",
+                        "format": "datetime",
+                        "example": "2022-04-18T13:15:30Z",
+                        "description": "The start time of the event, will always be Z"
+                    },
+                    "date_end": {
+                        "type": "string",
+                        "format": "datetime",
+                        "example": "2022-04-18T13:15:30Z",
+                        "description": "The end time of the event, will always be Z"
+                    },
+                    "flight_information_region_id": {
+                        "type": "integer",
+                        "format": "int64",
+                        "example": 1,
+                        "description": "The flight information region where this event is taking place"
+                    },
+                    "vatcan_code": {
+                        "type": "string",
+                        "format": "VATCAN event code",
+                        "nullable": true,
+                        "example": "abcd",
+                        "description": "The VATCAN booking code associated with this event, if present"
+                    },
+                    "participants": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "cid": {
+                                    "type": "integer",
+                                    "description": "A VATSIM CID",
+                                    "example": 1203533,
+                                    "nullable": false
+                                },
+                                "origin": {
+                                    "type": "string",
+                                    "format": "Airfield ICAO",
+                                    "description": "The origin airfield for the flight, may be NULL.",
+                                    "example": "EGKK",
+                                    "nullable": true
+                                },
+                                "destination": {
+                                    "type": "string",
+                                    "format": "Airfield ICAO",
+                                    "description": "The destination airfield for the flight, may be NULL.",
+                                    "example": "EHAM",
+                                    "nullable": true
+                                }
+                            }
+                        },
+                        "description": "Array of VATSIM Members participating in the event"
+                    }
+                }
+            },
+            "Events": {
+                "type": "array",
+                "items": {
+                    "$ref": "#/components/schemas/Event"
+                }
+            },
+            "FlightInformationRegion": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "integer",
+                        "format": "int64",
+                        "example": 10,
+                        "description": "System id"
+                    },
+                    "identifier": {
+                        "type": "string",
+                        "format": "ICAO code",
+                        "example": "EGTT",
+                        "minLength": 4,
+                        "maxLength": 4,
+                        "description": "The ICAO identifier for the FIR"
+                    },
+                    "name": {
+                        "type": "string",
+                        "example": "London",
+                        "description": "Other name for the FIR"
+                    }
+                }
+            },
+            "FlightInformationRegions": {
+                "type": "array",
+                "items": {
+                    "$ref": "#/components/schemas/FlightInformationRegion"
+                }
+            },
+            "FlowMeasures": {
+                "type": "array",
+                "items": {
+                    "$ref": "#/components/schemas/FlowMeasure"
+                }
+            },
+            "FlowMeasure": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "integer",
+                        "format": "int64",
+                        "example": 10,
+                        "description": "System id."
+                    },
+                    "ident": {
+                        "type": "string",
+                        "description": "Automatically assigned identifier for this flow measure - FIR, day of month, designator.",
+                        "example": "EGTT25B"
+                    },
+                    "event_id": {
+                        "type": "integer",
+                        "format": "int64",
+                        "description": "The identifier of the event for this flow measure",
+                        "example": 44
+                    },
+                    "reason": {
+                        "type": "string",
+                        "description": "Why this flow measure is being enforced",
+                        "example": "Due runway capacity"
+                    },
+                    "starttime": {
+                        "type": "string",
+                        "format": "datetime",
+                        "example": "2022-04-18T13:15:30Z"
+                    },
+                    "endtime": {
+                        "type": "string",
+                        "format": "datetime",
+                        "example": "2022-04-18T13:15:30Z"
+                    },
+                    "notified_flight_information_regions": {
+                        "type": "array",
+                        "description": "An array of flight information ids that are to be notified of this flow measure",
+                        "example": [
+                            1,
+                            2,
+                            42
+                        ],
+                        "items": {
+                            "type": "integer",
+                            "example": 5,
+                            "description": "The system id of a flight information region"
+                        }
+                    },
+                    "measure": {
+                        "oneOf": [
+                            {
+                                "type": "object",
+                                "properties": {
+                                    "type": {
+                                        "type": "string",
+                                        "enum": [
+                                            "minimum_departure_interval",
+                                            "average_departure_interval"
+                                        ]
+                                    },
+                                    "value": {
+                                        "type": "integer",
+                                        "format": "int64",
+                                        "description": "The number of seconds applicable to this measure",
+                                        "example": 120
+                                    }
+                                }
+                            },
+                            {
+                                "type": "object",
+                                "properties": {
+                                    "type": {
+                                        "type": "string",
+                                        "enum": [
+                                            "per_hour"
+                                        ]
+                                    },
+                                    "value": {
+                                        "type": "integer",
+                                        "format": "int64",
+                                        "description": "The number of flights per hour permitted",
+                                        "example": 5
+                                    }
+                                }
+                            },
+                            {
+                                "type": "object",
+                                "properties": {
+                                    "type": {
+                                        "type": "string",
+                                        "enum": [
+                                            "miles_in_trail"
+                                        ]
+                                    },
+                                    "value": {
+                                        "type": "integer",
+                                        "format": "int64",
+                                        "description": "The distance in nm of aircraft in trail",
+                                        "example": 5
+                                    }
+                                }
+                            },
+                            {
+                                "type": "object",
+                                "properties": {
+                                    "type": {
+                                        "type": "string",
+                                        "enum": [
+                                            "max_ias"
+                                        ]
+                                    },
+                                    "value": {
+                                        "type": "integer",
+                                        "format": "int64",
+                                        "description": "The maximum allowable indicated airspeed",
+                                        "example": 275
+                                    }
+                                }
+                            },
+                            {
+                                "type": "object",
+                                "properties": {
+                                    "type": {
+                                        "type": "string",
+                                        "enum": [
+                                            "max_mach"
+                                        ]
+                                    },
+                                    "value": {
+                                        "type": "integer",
+                                        "format": "int64",
+                                        "description": "The maximum allowable mach number",
+                                        "example": "82 = 0.82 Mach"
+                                    }
+                                }
+                            },
+                            {
+                                "type": "object",
+                                "properties": {
+                                    "type": {
+                                        "type": "string",
+                                        "enum": [
+                                            "ias_reduction"
+                                        ]
+                                    },
+                                    "value": {
+                                        "type": "integer",
+                                        "format": "int64",
+                                        "description": "How much to reduce indicated airspeed by",
+                                        "example": "50"
+                                    }
+                                }
+                            },
+                            {
+                                "type": "object",
+                                "properties": {
+                                    "type": {
+                                        "type": "string",
+                                        "enum": [
+                                            "mach_reduction"
+                                        ]
+                                    },
+                                    "value": {
+                                        "type": "integer",
+                                        "format": "int64",
+                                        "description": "How much to reduce mach number by",
+                                        "example": "5 = 0.05 Mach"
+                                    }
+                                }
+                            },
+                            {
+                                "type": "object",
+                                "properties": {
+                                    "type": {
+                                        "type": "string",
+                                        "enum": [
+                                            "prohibit"
+                                        ],
+                                        "description": "Prohibit a flight according to given filters"
+                                    },
+                                    "value": {
+                                        "type": "null"
+                                    }
+                                }
+                            },
+                            {
+                                "type": "object",
+                                "properties": {
+                                    "type": {
+                                        "type": "string",
+                                        "enum": [
+                                            "ground_stop"
+                                        ],
+                                        "description": "No departures are permitted"
+                                    },
+                                    "value": {
+                                        "type": "null"
+                                    }
+                                }
+                            },
+                            {
+                                "type": "object",
+                                "properties": {
+                                    "type": {
+                                        "type": "string",
+                                        "enum": [
+                                            "mandatory_route"
+                                        ]
+                                    },
+                                    "value": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "string",
+                                            "format": "JSON",
+                                            "description": "The specified mandatory route string",
+                                            "example": "UL612 LAKEY DCT NUGRA"
+                                        },
+                                        "format": "JSON",
+                                        "description": "Ar array of mandatory route strings, items are related via logical OR",
+                                        "example": [
+                                            "LOGAN",
+                                            "UL612 LAKEY DCT NUGRA"
+                                        ]
+                                    }
+                                }
+                            }
+                        ]
+                    },
+                    "filters": {
+                        "type": "array",
+                        "format": "JSON",
+                        "description": "The applicable filters for this flow measure. Multiple filters are joined by logical AND.",
+                        "minItems": 2,
+                        "items": {
+                            "anyOf": [
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "type": {
+                                            "type": "string",
+                                            "enum": [
+                                                "ADEP"
+                                            ]
+                                        },
+                                        "value": {
+                                            "type": "array",
+                                            "minItems": 1,
+                                            "description": "The departure airfields. Can be wildcarded with *. This filter is mandatory.",
+                                            "items": {
+                                                "type": "string"
+                                            },
+                                            "example": [
+                                                "EGKK",
+                                                "EGLL"
+                                            ]
+                                        }
+                                    }
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "type": {
+                                            "type": "string",
+                                            "enum": [
+                                                "ADES"
+                                            ]
+                                        },
+                                        "value": {
+                                            "description": "The departure airfields. Can be wildcarded with *. This filter is mandatory.",
+                                            "type": "array",
+                                            "minItems": 1,
+                                            "items": {
+                                                "type": "string"
+                                            },
+                                            "example": [
+                                                "EH**"
+                                            ]
+                                        }
+                                    }
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "type": {
+                                            "type": "string",
+                                            "enum": [
+                                                "level_above",
+                                                "level_below"
+                                            ]
+                                        },
+                                        "value": {
+                                            "description": "Three digit flight level. Values are inclusive.",
+                                            "type": "integer",
+                                            "example": 350
+                                        }
+                                    }
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "type": {
+                                            "type": "string",
+                                            "enum": [
+                                                "level"
+                                            ]
+                                        },
+                                        "value": {
+                                            "description": "List of three digit flight levels.",
+                                            "type": "array",
+                                            "minItems": 1,
+                                            "items": {
+                                                "type": "integer"
+                                            },
+                                            "example": [
+                                                360,
+                                                370,
+                                                380
+                                            ]
+                                        }
+                                    }
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "type": {
+                                            "type": "string",
+                                            "enum": [
+                                                "member_event",
+                                                "member_not_event"
+                                            ]
+                                        },
+                                        "value": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "object",
+                                                "properties": {
+                                                    "event_id": {
+                                                        "type": "integer",
+                                                        "example": 1,
+                                                        "description": "The id of the event in the API"
+                                                    },
+                                                    "event_vatcan": {
+                                                        "type": "string",
+                                                        "nullable": true,
+                                                        "description": "The events VATCAN code",
+                                                        "example": "ABCD01"
+                                                    },
+                                                    "event_api": {
+                                                        "type": "null",
+                                                        "description": "The events API code",
+                                                        "example": null
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "type": {
+                                            "type": "string",
+                                            "enum": [
+                                                "waypoint"
+                                            ]
+                                        },
+                                        "value": {
+                                            "type": "array",
+                                            "items": {
+                                                "description": "String of waypoints",
+                                                "type": "string",
+                                                "format": "JSON",
+                                                "example": "BIG UL9 CPT"
+                                            },
+                                            "description": "List of waypoint / route strings, joined via logical OR"
+                                        }
+                                    }
+                                }
+                            ]
+                        },
+                        "example": [
+                            {
+                                "type": "ADEP",
+                                "value": [
+                                    "EGKK",
+                                    "EGLL",
+                                    "EGSS"
+                                ]
+                            },
+                            {
+                                "type": "ADES",
+                                "value": [
+                                    "EH**"
+                                ]
+                            },
+                            {
+                                "type": "level",
+                                "value": [
+                                    230,
+                                    240
+                                ]
+                            }
+                        ]
+                    }
+                }
+            },
+            "Plugin": {
+                "type": "object",
+                "properties": {
+                    "events": {
+                        "$ref": "#/components/schemas/Events"
+                    },
+                    "flight_information_regions": {
+                        "$ref": "#/components/schemas/FlightInformationRegions"
+                    },
+                    "flow_measures": {
+                        "$ref": "#/components/schemas/FlowMeasures"
+                    }
+                }
+            }
         }
-      },
-      "Plugin": {
-        "type": "object",
-        "properties": {
-          "events": {
-            "$ref": "#/components/schemas/Events"
-          },
-          "flight_information_regions": {
-            "$ref": "#/components/schemas/FlightInformationRegions"
-          },
-          "flow_measures": {
-            "$ref": "#/components/schemas/FlowMeasures"
-          }
-        }
-      }
     }
-  }
 }

--- a/tests/Api/EventTest.php
+++ b/tests/Api/EventTest.php
@@ -76,7 +76,7 @@ class EventTest extends TestCase
                     'date_end' => ApiDateTimeFormatter::formatDateTime($event->date_end),
                     'flight_information_region_id' => $event->flight_information_region_id,
                     'vatcan_code' => $event->vatcan_code,
-                    'participants' => $event->participants->map(fn(EventParticipant $eventParticipant) => [
+                    'participants' => $event->participants->map(fn (EventParticipant $eventParticipant) => [
                         'cid' => $eventParticipant->cid,
                         'destination' => $eventParticipant->destination,
                         'origin' => $eventParticipant->origin,

--- a/tests/Api/EventTest.php
+++ b/tests/Api/EventTest.php
@@ -4,6 +4,7 @@ namespace Tests\Api;
 
 use App\Helpers\ApiDateTimeFormatter;
 use App\Models\Event;
+use App\Models\EventParticipant;
 use Illuminate\Support\Facades\DB;
 use Tests\TestCase;
 
@@ -37,7 +38,7 @@ class EventTest extends TestCase
                     'date_end' => ApiDateTimeFormatter::formatDateTime($event->date_end),
                     'flight_information_region_id' => $event->flight_information_region_id,
                     'vatcan_code' => null,
-                    'participants' => null,
+                    'participants' => [],
                 ]
             );
     }
@@ -56,7 +57,7 @@ class EventTest extends TestCase
                     'date_end' => ApiDateTimeFormatter::formatDateTime($event->date_end),
                     'flight_information_region_id' => $event->flight_information_region_id,
                     'vatcan_code' => $event->vatcan_code,
-                    'participants' => null,
+                    'participants' => [],
                 ]
             );
     }
@@ -75,7 +76,11 @@ class EventTest extends TestCase
                     'date_end' => ApiDateTimeFormatter::formatDateTime($event->date_end),
                     'flight_information_region_id' => $event->flight_information_region_id,
                     'vatcan_code' => $event->vatcan_code,
-                    'participants' => $event->participants,
+                    'participants' => $event->participants->map(fn(EventParticipant $eventParticipant) => [
+                        'cid' => $eventParticipant->cid,
+                        'destination' => $eventParticipant->destination,
+                        'origin' => $eventParticipant->origin,
+                    ])
                 ]
             );
     }
@@ -103,7 +108,7 @@ class EventTest extends TestCase
                         'date_end' => ApiDateTimeFormatter::formatDateTime($event1->date_end),
                         'flight_information_region_id' => $event1->flight_information_region_id,
                         'vatcan_code' => null,
-                        'participants' => null,
+                        'participants' => [],
                     ],
                     [
                         'id' => $event2->id,
@@ -112,7 +117,7 @@ class EventTest extends TestCase
                         'date_end' => ApiDateTimeFormatter::formatDateTime($event2->date_end),
                         'flight_information_region_id' => $event2->flight_information_region_id,
                         'vatcan_code' => null,
-                        'participants' => null,
+                        'participants' => [],
                     ],
                 ]
             );
@@ -135,7 +140,7 @@ class EventTest extends TestCase
                         'date_end' => ApiDateTimeFormatter::formatDateTime($event->date_end),
                         'flight_information_region_id' => $event->flight_information_region_id,
                         'vatcan_code' => null,
-                        'participants' => null,
+                        'participants' => [],
                     ],
                 ]
             );

--- a/tests/Feature/Filament/EventResourceTest.php
+++ b/tests/Feature/Filament/EventResourceTest.php
@@ -185,7 +185,7 @@ it('can retrieve data for edit page', function () {
         ->assertSet('data.date_start', $event->date_start->toDateTimeString())
         ->assertSet('data.date_end', $event->date_end->toDateTimeString())
         ->assertSet('data.vatcan_code', $event->vatcan_code)
-        ->assertSet('data.participants', $event->participants);
+        ->assertSet('data.participants.cid', $event->participants->pluck('cid'));
 });
 
 it('can edit', function () {
@@ -266,5 +266,5 @@ it('can retrieve data for view page', function () {
         ->assertSet('data.date_start', $event->date_start->toDateTimeString())
         ->assertSet('data.date_end', $event->date_end->toDateTimeString())
         ->assertSet('data.vatcan_code', $event->vatcan_code)
-        ->assertSet('data.participants', $event->participants);
+        ->assertSet('data.participants.cid', $event->participants->pluck('cid'));
 });

--- a/tests/Imports/EventParticipantsImportTest.php
+++ b/tests/Imports/EventParticipantsImportTest.php
@@ -157,6 +157,33 @@ class EventParticipantsImportTest extends TestCase
         );
     }
 
+    public function testItAddsEventParticipantsWithNoOriginAndDestination()
+    {
+        $rows = collect([collect([1203533]), collect([1203534])]);
+        $this->import->collection($rows);
+
+        $this->assertDatabaseCount(
+            'event_participants',
+            2
+        );
+        $this->assertDatabaseHas(
+            'event_participants',
+            [
+                'cid' => 1203533,
+                'origin' => null,
+                'destination' => null,
+            ]
+        );
+        $this->assertDatabaseHas(
+            'event_participants',
+            [
+                'cid' => 1203534,
+                'origin' => null,
+                'destination' => null,
+            ]
+        );
+    }
+
     public function testItRemovesPreviousEventParticipantsForEvent()
     {
         $otherEvent = Event::factory()->withParticipants()->create();

--- a/tests/Imports/EventParticipantsImportTest.php
+++ b/tests/Imports/EventParticipantsImportTest.php
@@ -1,6 +1,5 @@
 <?php
 
-
 namespace Tests\Imports;
 
 use App\Imports\EventParticipantsImport;

--- a/tests/Imports/EventParticipantsImportTest.php
+++ b/tests/Imports/EventParticipantsImportTest.php
@@ -1,0 +1,205 @@
+<?php
+
+
+namespace Tests\Imports;
+
+use App\Imports\EventParticipantsImport;
+use App\Models\Event;
+use App\Models\EventParticipant;
+use Tests\TestCase;
+
+class EventParticipantsImportTest extends TestCase
+{
+    private readonly Event $event;
+    private readonly EventParticipantsImport $import;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->event = Event::factory()->create();
+        $this->import = new EventParticipantsImport($this->event, 'abc');
+    }
+
+    /**
+     * @dataProvider badDataProvider
+     */
+    public function testItIgnoresRowsWithBadData(array $row)
+    {
+        $this->import->collection(collect([collect([$row])]));
+        $this->assertDatabaseCount('event_participants', 0);
+    }
+
+    public function badDataProvider(): array
+    {
+        return [
+            'CID null' => [[null, 'EGKK', 'EGLL']],
+            'CID not a number' => [['abc', 'EGKK', 'EGLL']],
+            'CID a float' => [[1203533.123, 'EGKK', 'EGLL']],
+            'CID too low' => [[799999, 'EGKK', 'EGLL']],
+            'CID too high for founder' => [[800151, 'EGKK', 'EGLL']],
+            'CID too low for members' => [[809999, 'EGKK', 'EGLL']],
+            'Origin too short, 1 character' => [[1203533, 'E', 'EGLL']],
+            'Origin too short, 2 characters' => [[1203533, 'EG', 'EGLL']],
+            'Origin too short, 3 characters' => [[1203533, 'EGG', 'EGLL']],
+            'Origin too long, 5 characters' => [[1203533, 'EGGDX', 'EGLL']],
+            'Destination too short, 1 character' => [[1203533, 'EGKK', 'E']],
+            'Destination too short, 2 characters' => [[1203533, 'EGKK', 'EG']],
+            'Destination too short, 3 characters' => [[1203533, 'EGKK', 'EGG']],
+            'Origin invalid characters' => [[1203533, 'EG1F', 'EGGD']],
+            'Destination invalid characters' => [[1203533, 'EGGD', 'EB44']],
+        ];
+    }
+
+    public function testItAddsEventParticipants()
+    {
+        $rows = collect([collect([1203533, 'EGKK', 'EGLL']), collect([1203534, 'EGSS', 'LXGB'])]);
+        $this->import->collection($rows);
+
+        $this->assertDatabaseCount(
+            'event_participants',
+            2
+        );
+        $this->assertDatabaseHas(
+            'event_participants',
+            [
+                'cid' => 1203533,
+                'origin' => 'EGKK',
+                'destination' => 'EGLL'
+            ]
+        );
+        $this->assertDatabaseHas(
+            'event_participants',
+            [
+                'cid' => 1203534,
+                'origin' => 'EGSS',
+                'destination' => 'LXGB'
+            ]
+        );
+    }
+
+    public function testItAddsEventParticipantsCaseInsensitive()
+    {
+        $rows = collect([collect([1203533, 'EGKK', 'egll']), collect([1203534, 'egss', 'LXGB'])]);
+        $this->import->collection($rows);
+
+        $this->assertDatabaseCount(
+            'event_participants',
+            2
+        );
+        $this->assertDatabaseHas(
+            'event_participants',
+            [
+                'cid' => 1203533,
+                'origin' => 'EGKK',
+                'destination' => 'EGLL'
+            ]
+        );
+        $this->assertDatabaseHas(
+            'event_participants',
+            [
+                'cid' => 1203534,
+                'origin' => 'EGSS',
+                'destination' => 'LXGB'
+            ]
+        );
+    }
+
+    public function testItAddsEventParticipantsWithNullOriginAndDestination()
+    {
+        $rows = collect([collect([1203533, null, null]), collect([1203534, null, null])]);
+        $this->import->collection($rows);
+
+        $this->assertDatabaseCount(
+            'event_participants',
+            2
+        );
+        $this->assertDatabaseHas(
+            'event_participants',
+            [
+                'cid' => 1203533,
+                'origin' => null,
+                'destination' => null,
+            ]
+        );
+        $this->assertDatabaseHas(
+            'event_participants',
+            [
+                'cid' => 1203534,
+                'origin' => null,
+                'destination' => null,
+            ]
+        );
+    }
+
+    public function testItAddsEventParticipantsWithEmptyOriginAndDestination()
+    {
+        $rows = collect([collect([1203533, '', '']), collect([1203534, '', ''])]);
+        $this->import->collection($rows);
+
+        $this->assertDatabaseCount(
+            'event_participants',
+            2
+        );
+        $this->assertDatabaseHas(
+            'event_participants',
+            [
+                'cid' => 1203533,
+                'origin' => null,
+                'destination' => null,
+            ]
+        );
+        $this->assertDatabaseHas(
+            'event_participants',
+            [
+                'cid' => 1203534,
+                'origin' => null,
+                'destination' => null,
+            ]
+        );
+    }
+
+    public function testItRemovesPreviousEventParticipantsForEvent()
+    {
+        $otherEvent = Event::factory()->withParticipants()->create();
+        $otherEventParticipants = EventParticipant::where('event_id', $otherEvent->id)->get();
+
+        $this->event->participants()->createMany(
+            [
+                [
+                    'cid' => 1203533,
+                    'origin' => 'EGKK',
+                    'destination' => 'EGCC'
+                ],
+                [
+                    'cid' => 1203532,
+                    'origin' => 'EGPH',
+                    'destination' => 'EIDW'
+                ]
+            ]
+        );
+        $rows = collect([collect([1203533, 'EGKK', 'EGLL']), collect([1203534, 'EGSS', 'LXGB'])]);
+        $this->import->collection($rows);
+
+        $this->assertEquals($otherEventParticipants, EventParticipant::where('event_id', $otherEvent->id)->get());
+        $this->assertDatabaseCount(
+            'event_participants',
+            $otherEventParticipants->count() + 2
+        );
+        $this->assertDatabaseHas(
+            'event_participants',
+            [
+                'cid' => 1203533,
+                'origin' => 'EGKK',
+                'destination' => 'EGLL'
+            ]
+        );
+        $this->assertDatabaseHas(
+            'event_participants',
+            [
+                'cid' => 1203534,
+                'origin' => 'EGSS',
+                'destination' => 'LXGB'
+            ]
+        );
+    }
+}


### PR DESCRIPTION
- Allow event participant uploads to include an optional origin and destination airfield
- Store event participants in new `event_participants` table and drop old column
- Update API + spec to display new participants formats
- Viewing event in filament displays all the CIDs involved in the event