### PR TITLE
feat: event api updates

### DIFF
--- a/app/Http/Controllers/EventController.php
+++ b/app/Http/Controllers/EventController.php
@@ -3,19 +3,61 @@
 namespace App\Http\Controllers;
 
 use App\Http\Resources\EventResource;
-use App\Models\Event;
+use App\Repository\EventRepository;
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;
 
 class EventController
 {
+    private readonly EventRepository $repository;
+
+    public function __construct(EventRepository $repository)
+    {
+        $this->repository = $repository;
+    }
+
     public function getFilteredEvents(Request $request): JsonResource
     {
-        $query = Event::query();
-        if ((int)$request->input('active') === 1) {
-            $query->active();
+        if ($this->activeAndUpcoming($request)) {
+            $flowMeasures = $this->repository->getActiveAndUpcomingEvents(
+                $this->includeTrashed($request)
+            );
+        } else {
+            if ($this->onlyActive($request)) {
+                $flowMeasures = $this->repository->getActiveEvents($this->includeTrashed($request));
+            } else {
+                if ($this->onlyUpcoming($request)) {
+                    $flowMeasures = $this->repository->getUpcomingEvents(
+                        $this->includeTrashed($request)
+                    );
+                } else {
+                    $flowMeasures = $this->repository->getApiRelevantEvents(
+                        $this->includeTrashed($request)
+                    );
+                }
+            }
         }
 
-        return EventResource::collection($query->get());
+        return EventResource::collection($flowMeasures);
+    }
+
+    private function includeTrashed(Request $request): bool
+    {
+        return (int)$request->input('deleted') === 1;
+    }
+
+    private function onlyActive(Request $request): bool
+    {
+        return (int)$request->input('active') === 1;
+    }
+
+    private function onlyUpcoming(Request $request): bool
+    {
+        return (int)$request->input('upcoming') === 1;
+    }
+
+    private function activeAndUpcoming(Request $request): bool
+    {
+        return $this->onlyActive($request) && $this->onlyUpcoming($request);
     }
 }

--- a/app/Http/Controllers/EventController.php
+++ b/app/Http/Controllers/EventController.php
@@ -25,6 +25,8 @@ class EventController
         } else {
             if ($this->onlyActive($request)) {
                 $flowMeasures = $this->repository->getActiveEvents($this->includeTrashed($request));
+            } else if ($this->onlyFinished($request)) {
+                $flowMeasures = $this->repository->getFinishedEvents($this->includeTrashed($request));
             } else {
                 if ($this->onlyUpcoming($request)) {
                     $flowMeasures = $this->repository->getUpcomingEvents(
@@ -54,6 +56,11 @@ class EventController
     private function onlyUpcoming(Request $request): bool
     {
         return (int)$request->input('upcoming') === 1;
+    }
+
+    private function onlyFinished(Request $request): bool
+    {
+        return (int)$request->input('finished') === 1;
     }
 
     private function activeAndUpcoming(Request $request): bool

--- a/app/Repository/EventRepository.php
+++ b/app/Repository/EventRepository.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace App\Repository;
+
+use App\Models\Event;
+use Carbon\Carbon;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Collection;
+
+class EventRepository
+{
+    public function getApiRelevantEvents(bool $includeDeleted): Collection
+    {
+        return $this->upcomingQuery($includeDeleted)
+            ->union($this->endTimeWithinOneDayQuery($includeDeleted))
+            ->orderBy('id')
+            ->get();
+    }
+
+    public function getActiveEvents(bool $includeDeleted): Collection
+    {
+        return $this->activeQuery($includeDeleted)
+            ->orderBy('id')
+            ->get();
+    }
+
+    public function getUpcomingEvents(bool $includeDeleted): Collection
+    {
+        return $this->upcomingQuery($includeDeleted)
+            ->orderBy('id')
+            ->get();
+    }
+
+    public function getActiveAndUpcomingEvents(bool $includeDeleted): Collection
+    {
+        return $this->upcomingQuery($includeDeleted)
+            ->union($this->activeQuery($includeDeleted))
+            ->orderBy('id')
+            ->get();
+    }
+
+    private function activeQuery(bool $includeDeleted): Builder
+    {
+        $now = Carbon::now();
+
+        return $this->baseQuery($includeDeleted)
+            ->where('date_start', '<=', $now)
+            ->where('date_end', '>', $now);
+    }
+
+    private function upcomingQuery(bool $includeDeleted): Builder
+    {
+        return $this->baseQuery($includeDeleted)
+            ->where('date_start', '<', Carbon::now()->addDay())
+            ->where('date_start', '>', Carbon::now());
+    }
+
+    private function endTimeWithinOneDayQuery(bool $includeDeleted): Builder
+    {
+        return $this->baseQuery($includeDeleted)
+            ->where('date_start', '<', Carbon::now())
+            ->where('date_end', '>', Carbon::now()->subDay());
+    }
+
+    private function baseQuery(bool $includeDeleted): Builder
+    {
+        return tap(
+            Event::query(),
+            function (Builder $builder) use ($includeDeleted) {
+                if ($includeDeleted) {
+                    $builder->withTrashed();
+                }
+            }
+        );
+    }
+}

--- a/app/Repository/EventRepository.php
+++ b/app/Repository/EventRepository.php
@@ -39,6 +39,14 @@ class EventRepository
             ->get();
     }
 
+    public function getFinishedEvents(bool $includeDeleted): Collection
+    {
+        return $this->baseQuery($includeDeleted)
+            ->where('date_end', '<', Carbon::now())
+            ->orderBy('id')
+            ->get();
+    }
+
     private function activeQuery(bool $includeDeleted): Builder
     {
         $now = Carbon::now();

--- a/database/factories/EventFactory.php
+++ b/database/factories/EventFactory.php
@@ -4,6 +4,7 @@ namespace Database\Factories;
 
 use App\Models\EventParticipant;
 use App\Models\FlightInformationRegion;
+use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 class EventFactory extends Factory
@@ -29,15 +30,23 @@ class EventFactory extends Factory
 
     public function notStarted(): static
     {
-        return $this->state(fn (array $attributes) => [
+        return $this->state(fn(array $attributes) => [
             'date_start' => $this->faker->dateTimeBetween('now + 1 minute', 'now + 1 hour'),
             'date_end' => $this->faker->dateTimeBetween('now + 2 hour', 'now + 3 hour'),
         ]);
     }
 
+    public function withTimes(Carbon $startTime, Carbon $endTime): static
+    {
+        return $this->state(fn(array $attributes) => [
+            'date_start' => $startTime,
+            'date_end' => $endTime,
+        ]);
+    }
+
     public function withVatcanCode(): static
     {
-        return $this->state(fn (array $attributes) => [
+        return $this->state(fn(array $attributes) => [
             'vatcan_code' => $this->faker->word(),
         ]);
     }

--- a/spec/api-spec-v1.json
+++ b/spec/api-spec-v1.json
@@ -150,19 +150,48 @@
                     "Events"
                 ],
                 "summary": "Get all events",
-                "description": "GET /event",
+                "description": "Get all events. By default, will return events starting in the next 24 hours, up until 24 hours after they finish.",
                 "operationId": "getEvents",
                 "parameters": [
                     {
-                        "name": "active",
                         "in": "query",
-                        "description": "Only return active events",
-                        "required": false,
+                        "name": "deleted",
                         "schema": {
                             "type": "integer",
-                            "format": "int64",
                             "example": 1
-                        }
+                        },
+                        "required": false,
+                        "description": "Include deleted events"
+                    },
+                    {
+                        "in": "query",
+                        "name": "active",
+                        "schema": {
+                            "type": "integer",
+                            "example": 1
+                        },
+                        "required": false,
+                        "description": "Only include events that are currently active, can be used in combination with upcoming"
+                    },
+                    {
+                        "in": "query",
+                        "name": "upcoming",
+                        "schema": {
+                            "type": "integer",
+                            "example": 1
+                        },
+                        "required": false,
+                        "description": "Only include events that are upcoming in the next 24 hours, can be used in combination with active"
+                    },
+                    {
+                        "in": "query",
+                        "name": "finished",
+                        "schema": {
+                            "type": "integer",
+                            "example": 1
+                        },
+                        "required": false,
+                        "description": "Only include events that are finished"
                     }
                 ],
                 "responses": {
@@ -289,7 +318,7 @@
                     "Flow Measures"
                 ],
                 "summary": "Get all flow measures",
-                "description": "GET /flow-measure",
+                "description": "Get all flow measures. By default, will return measures starting in the next 24 hours, up until 24 hours after they finish.",
                 "operationId": "getFlowMeasures",
                 "parameters": [
                     {

--- a/tests/Api/EventTest.php
+++ b/tests/Api/EventTest.php
@@ -466,4 +466,113 @@ class EventTest extends TestCase
                 ],
             ]);
     }
+
+    public function testItReturnsFinishedEventsWithoutDeleted()
+    {
+        // Should show
+        $event1 = Event::factory()
+            ->finished()
+            ->create();
+
+        $event2 = Event::factory()
+            ->finished()
+            ->create();
+
+        // Should not show - active
+        Event::factory()
+            ->create();
+
+        // Should not show - upcoming
+        Event::factory()
+            ->notStarted()
+            ->create();
+
+        // Shouldn't show - deleted
+        $deleted = Event::factory()
+            ->finished()
+            ->create();
+        $deleted->delete();
+
+        $this->get('api/v1/event?finished=1')
+            ->assertOk()
+            ->assertExactJson([
+                [
+                    'id' => $event1->id,
+                    'name' => $event1->name,
+                    'date_start' => ApiDateTimeFormatter::formatDateTime($event1->date_start),
+                    'date_end' => ApiDateTimeFormatter::formatDateTime($event1->date_end),
+                    'flight_information_region_id' => $event1->flight_information_region_id,
+                    'vatcan_code' => $event1->vatcan_code,
+                    'participants' => [],
+                ],
+                [
+                    'id' => $event2->id,
+                    'name' => $event2->name,
+                    'date_start' => ApiDateTimeFormatter::formatDateTime($event2->date_start),
+                    'date_end' => ApiDateTimeFormatter::formatDateTime($event2->date_end),
+                    'flight_information_region_id' => $event2->flight_information_region_id,
+                    'vatcan_code' => $event2->vatcan_code,
+                    'participants' => [],
+                ],
+            ]);
+    }
+
+    public function testItReturnsFinishedEventsWithDeleted()
+    {
+        // Should show
+        $event1 = Event::factory()
+            ->finished()
+            ->create();
+
+        $event2 = Event::factory()
+            ->finished()
+            ->create();
+
+        // Should not show - active
+        Event::factory()
+            ->create();
+
+        // Should not show - upcoming
+        Event::factory()
+            ->notStarted()
+            ->create();
+
+        // Shouldn't show - deleted
+        $deleted = Event::factory()
+            ->finished()
+            ->create();
+        $deleted->delete();
+
+        $this->get('api/v1/event?finished=1&deleted=1')
+            ->assertOk()
+            ->assertExactJson([
+                [
+                    'id' => $event1->id,
+                    'name' => $event1->name,
+                    'date_start' => ApiDateTimeFormatter::formatDateTime($event1->date_start),
+                    'date_end' => ApiDateTimeFormatter::formatDateTime($event1->date_end),
+                    'flight_information_region_id' => $event1->flight_information_region_id,
+                    'vatcan_code' => $event1->vatcan_code,
+                    'participants' => [],
+                ],
+                [
+                    'id' => $event2->id,
+                    'name' => $event2->name,
+                    'date_start' => ApiDateTimeFormatter::formatDateTime($event2->date_start),
+                    'date_end' => ApiDateTimeFormatter::formatDateTime($event2->date_end),
+                    'flight_information_region_id' => $event2->flight_information_region_id,
+                    'vatcan_code' => $event2->vatcan_code,
+                    'participants' => [],
+                ],
+                [
+                    'id' => $deleted->id,
+                    'name' => $deleted->name,
+                    'date_start' => ApiDateTimeFormatter::formatDateTime($deleted->date_start),
+                    'date_end' => ApiDateTimeFormatter::formatDateTime($deleted->date_end),
+                    'flight_information_region_id' => $deleted->flight_information_region_id,
+                    'vatcan_code' => $deleted->vatcan_code,
+                    'participants' => [],
+                ],
+            ]);
+    }
 }

--- a/tests/Repository/EventRepositoryTest.php
+++ b/tests/Repository/EventRepositoryTest.php
@@ -1,0 +1,308 @@
+<?php
+
+namespace Tests\Repository;
+
+use App\Models\Event;
+use App\Repository\EventRepository;
+use Carbon\Carbon;
+use Tests\TestCase;
+
+class EventRepositoryTest extends TestCase
+{
+    private readonly EventRepository $eventRepository;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->eventRepository = $this->app->make(EventRepository::class);
+    }
+
+    public function testItReturnsApiRelevantEvents()
+    {
+        // Should show
+        $upcoming = Event::factory()
+            ->notStarted()
+            ->create();
+
+        $active = Event::factory()
+            ->create();
+
+        $finished = Event::factory()
+            ->finished()
+            ->create();
+
+        // Shouldn't show, too far in the future
+        Event::factory()
+            ->withTimes(Carbon::now()->addDay()->addHour(), Carbon::now()->addDay()->addHours(2))
+            ->create();
+
+        // Shouldn't show, too far in the past
+        Event::factory()
+            ->withTimes(Carbon::now()->subDay()->subHours(3), Carbon::now()->subDay()->subHours(2))
+            ->create();
+
+        // Shouldn't show, deleted.
+        $deleted = Event::factory()
+            ->finished()
+            ->create();
+        $deleted->delete();
+
+        $expected = [$upcoming->id, $active->id, $finished->id];
+        $actual = $this->eventRepository->getApiRelevantEvents(false)
+            ->pluck('id')
+            ->sort()
+            ->toArray();
+
+        $this->assertEquals($expected, $actual);
+    }
+
+    public function testItReturnsApiRelevantDeletedEvents()
+    {
+        // Should show
+        $upcoming = Event::factory()
+            ->notStarted()
+            ->create();
+        $upcoming->delete();
+
+        $active = Event::factory()
+            ->create();
+
+        $finished = Event::factory()
+            ->finished()
+            ->create();
+        $finished->delete();
+
+        // Shouldn't show, too far in the future
+        Event::factory()
+            ->withTimes(Carbon::now()->addDay()->addHour(), Carbon::now()->addDay()->addHours(2))
+            ->create();
+
+        // Shouldn't show, too far in the past
+        Event::factory()
+            ->withTimes(Carbon::now()->subDay()->subHours(3), Carbon::now()->subDay()->subHours(2))
+            ->create();
+
+        $expected = [$upcoming->id, $active->id, $finished->id];
+        $actual = $this->eventRepository->getApiRelevantEvents(true)
+            ->pluck('id')
+            ->sort()
+            ->toArray();
+
+        $this->assertEquals($expected, $actual);
+    }
+
+    public function testItReturnsActiveEventsWithoutDeleted()
+    {
+        // Should show
+        $active1 = Event::factory()
+            ->create();
+
+        $active2 = Event::factory()
+            ->create();
+
+        $active3 = Event::factory()
+            ->create();
+
+        // Shouldn't show, not started
+        Event::factory()
+            ->notStarted()
+            ->create();
+
+        // Shouldn't show, finished
+        Event::factory()
+            ->finished()
+            ->create();
+
+        // Shouldn't show, deleted
+        $deleted = Event::factory()
+            ->create();
+        $deleted->delete();
+
+        $expected = [$active1->id, $active2->id, $active3->id];
+        $actual = $this->eventRepository->getActiveEvents(false)
+            ->pluck('id')
+            ->sort()
+            ->toArray();
+
+        $this->assertEquals($expected, $actual);
+    }
+
+    public function testItReturnsActiveEventsWithDeleted()
+    {
+        // Should show
+        $active1 = Event::factory()
+            ->create();
+
+        $active2 = Event::factory()
+            ->create();
+
+        $active3 = Event::factory()
+            ->create();
+
+        $deleted = Event::factory()
+            ->create();
+        $deleted->delete();
+
+        // Shouldn't show, not started
+        Event::factory()
+            ->notStarted()
+            ->create();
+
+        // Shouldn't show, finished
+        Event::factory()
+            ->finished()
+            ->create();
+
+        $expected = [$active1->id, $active2->id, $active3->id, $deleted->id];
+        $actual = $this->eventRepository->getActiveEvents(true)
+            ->pluck('id')
+            ->sort()
+            ->toArray();
+
+        $this->assertEquals($expected, $actual);
+    }
+
+    public function testItReturnsUpcomingEventsWithoutDeleted()
+    {
+        // Should show
+        $upcoming1 = Event::factory()
+            ->notStarted()
+            ->create();
+
+        $upcoming2 = Event::factory()
+            ->notStarted()
+            ->create();
+
+        $upcoming3 = Event::factory()
+            ->notStarted()
+            ->create();
+
+        // Shouldn't show, active
+        Event::factory()
+            ->create();
+
+        // Shouldn't show, finished
+        Event::factory()
+            ->finished()
+            ->create();
+
+        // Shouldn't show, deleted
+        $deleted = Event::factory()
+            ->notStarted()
+            ->create();
+        $deleted->delete();
+
+        $expected = [$upcoming1->id, $upcoming2->id, $upcoming3->id];
+        $actual = $this->eventRepository->getUpcomingEvents(false)
+            ->pluck('id')
+            ->sort()
+            ->toArray();
+
+        $this->assertEquals($expected, $actual);
+    }
+
+    public function testItReturnsUpcomingEventsWithDeleted()
+    {
+        // Should show
+        $upcoming1 = Event::factory()
+            ->notStarted()
+            ->create();
+
+        $upcoming2 = Event::factory()
+            ->notStarted()
+            ->create();
+
+        $upcoming3 = Event::factory()
+            ->notStarted()
+            ->create();
+
+        $deleted = Event::factory()
+            ->notStarted()
+            ->create();
+        $deleted->delete();
+
+        // Shouldn't show, active
+        Event::factory()
+            ->create();
+
+        // Shouldn't show, finished
+        Event::factory()
+            ->finished()
+            ->create();
+
+        $expected = [$upcoming1->id, $upcoming2->id, $upcoming3->id, $deleted->id];
+        $actual = $this->eventRepository->getUpcomingEvents(true)
+            ->pluck('id')
+            ->sort()
+            ->toArray();
+
+        $this->assertEquals($expected, $actual);
+    }
+
+    public function testItReturnsUpcomingAndActiveEventsWithoutDeleted()
+    {
+        // Should show
+        $upcoming1 = Event::factory()
+            ->notStarted()
+            ->create();
+
+        $upcoming2 = Event::factory()
+            ->notStarted()
+            ->create();
+
+        $active = Event::factory()
+            ->create();
+
+        // Shouldn't show, finished
+        Event::factory()
+            ->finished()
+            ->create();
+
+        // Shouldn't show, deleted
+        $deleted = Event::factory()
+            ->notStarted()
+            ->create();
+        $deleted->delete();
+
+        $expected = [$upcoming1->id, $upcoming2->id, $active->id];
+        $actual = $this->eventRepository->getActiveAndUpcomingEvents(false)
+            ->pluck('id')
+            ->sort()
+            ->toArray();
+
+        $this->assertEquals($expected, $actual);
+    }
+
+    public function testItReturnsUpcomingAndActiveEventsWithDeleted()
+    {
+        // Should show
+        $upcoming1 = Event::factory()
+            ->notStarted()
+            ->create();
+
+        $upcoming2 = Event::factory()
+            ->notStarted()
+            ->create();
+
+        $active = Event::factory()
+            ->create();
+
+        $deletedUpcoming = Event::factory()
+            ->notStarted()
+            ->create();
+        $deletedUpcoming->delete();
+
+        $deletedActive = Event::factory()
+            ->create();
+        $deletedActive->delete();
+
+        $expected = [$upcoming1->id, $upcoming2->id, $active->id, $deletedUpcoming->id, $deletedActive->id];
+
+        $actual = $this->eventRepository->getActiveAndUpcomingEvents(true)
+            ->pluck('id')
+            ->sort()
+            ->toArray();
+
+        $this->assertEquals($expected, $actual);
+    }
+}

--- a/tests/Repository/EventRepositoryTest.php
+++ b/tests/Repository/EventRepositoryTest.php
@@ -305,4 +305,76 @@ class EventRepositoryTest extends TestCase
 
         $this->assertEquals($expected, $actual);
     }
+
+    public function testItReturnsFinishedEventsWithoutDeleted()
+    {
+        // Should show
+        $finished1 = Event::factory()
+            ->finished()
+            ->create();
+
+        $finished2 = Event::factory()
+            ->finished()
+            ->create();
+
+        // Should not show - active
+        Event::factory()
+            ->create();
+
+        // Should not show - upcoming
+        Event::factory()
+            ->notStarted()
+            ->create();
+
+        // Should not show - deleted
+        $deleted = Event::factory()
+            ->finished()
+            ->create();
+        $deleted->delete();
+
+        $expected = [$finished1->id, $finished2->id];
+
+        $actual = $this->eventRepository->getFinishedEvents(false)
+            ->pluck('id')
+            ->sort()
+            ->toArray();
+
+        $this->assertEquals($expected, $actual);
+    }
+
+    public function testItReturnsFinishedEventsWithDeleted()
+    {
+        // Should show
+        $finished1 = Event::factory()
+            ->finished()
+            ->create();
+
+        $finished2 = Event::factory()
+            ->finished()
+            ->create();
+
+        // Should not show - active
+        Event::factory()
+            ->create();
+
+        // Should not show - upcoming
+        Event::factory()
+            ->notStarted()
+            ->create();
+
+        // Should show - deleted
+        $deleted = Event::factory()
+            ->finished()
+            ->create();
+        $deleted->delete();
+
+        $expected = [$finished1->id, $finished2->id, $deleted->id];
+
+        $actual = $this->eventRepository->getFinishedEvents(true)
+            ->pluck('id')
+            ->sort()
+            ->toArray();
+
+        $this->assertEquals($expected, $actual);
+    }
 }


### PR DESCRIPTION
- Update the event api to behave like Flow Measures in terms of default response (24 hours before start, 24 hours after finished)
- Additional filtering options for upcoming, deleted and finished on the event api