### PR TITLE
Division discord multiple tags

### DIFF
--- a/app/Discord/FlowMeasure/Content/DivisionWebhookRecipients.php
+++ b/app/Discord/FlowMeasure/Content/DivisionWebhookRecipients.php
@@ -3,18 +3,21 @@
 namespace App\Discord\FlowMeasure\Content;
 
 use App\Discord\Message\Tag\TagInterface;
+use Illuminate\Support\Collection;
 
 class DivisionWebhookRecipients implements FlowMeasureRecipientsInterface
 {
-    private readonly TagInterface $tag;
+    private readonly Collection $tags;
 
-    public function __construct(TagInterface $tag)
+    public function __construct(Collection $tags)
     {
-        $this->tag = $tag;
+        $this->tags = $tags;
     }
 
     public function toString(): string
     {
-        return (string)$this->tag;
+        return $this->tags
+            ->map(fn(TagInterface $tag) => (string)$tag)
+            ->join(' ');
     }
 }

--- a/app/Discord/FlowMeasure/Content/DivisionWebhookRecipients.php
+++ b/app/Discord/FlowMeasure/Content/DivisionWebhookRecipients.php
@@ -17,7 +17,7 @@ class DivisionWebhookRecipients implements FlowMeasureRecipientsInterface
     public function toString(): string
     {
         return $this->tags
-            ->map(fn(TagInterface $tag) => (string)$tag)
+            ->map(fn (TagInterface $tag) => (string)$tag)
             ->join(' ');
     }
 }

--- a/app/Discord/FlowMeasure/Content/FlowMeasureRecipientsFactory.php
+++ b/app/Discord/FlowMeasure/Content/FlowMeasureRecipientsFactory.php
@@ -49,12 +49,13 @@ class FlowMeasureRecipientsFactory
         $recipients = DivisionDiscordWebhook::find($pendingMessage->webhook()->id())
             ->flightInformationRegions
             ->filter(
-                fn(FlightInformationRegion $flightInformationRegion) => $pendingMessage
+                fn (FlightInformationRegion $flightInformationRegion) => $pendingMessage
                     ->flowMeasure()
                     ->notifiedFlightInformationRegions
-                    ->firstWhere(fn(FlightInformationRegion $notifiedFir) => $notifiedFir->id === $flightInformationRegion->id))
-            ->filter(fn(FlightInformationRegion $flightInformationRegion) => !empty($flightInformationRegion->pivot->tag))
-            ->map(fn(FlightInformationRegion $flightInformationRegion) => new Tag($flightInformationRegion->pivot));
+                    ->firstWhere(fn (FlightInformationRegion $notifiedFir) => $notifiedFir->id === $flightInformationRegion->id)
+            )
+            ->filter(fn (FlightInformationRegion $flightInformationRegion) => !empty($flightInformationRegion->pivot->tag))
+            ->map(fn (FlightInformationRegion $flightInformationRegion) => new Tag($flightInformationRegion->pivot));
 
         return $recipients->isEmpty()
             ? new NoRecipients()

--- a/app/Discord/FlowMeasure/Content/FlowMeasureRecipientsFactory.php
+++ b/app/Discord/FlowMeasure/Content/FlowMeasureRecipientsFactory.php
@@ -46,10 +46,18 @@ class FlowMeasureRecipientsFactory
 
     private function divisionRecipients(PendingMessageInterface $pendingMessage): FlowMeasureRecipientsInterface
     {
-        $divisionWebhook = DivisionDiscordWebhook::find($pendingMessage->webhook()->id());
+        $recipients = DivisionDiscordWebhook::find($pendingMessage->webhook()->id())
+            ->flightInformationRegions
+            ->filter(
+                fn(FlightInformationRegion $flightInformationRegion) => $pendingMessage
+                    ->flowMeasure()
+                    ->notifiedFlightInformationRegions
+                    ->firstWhere(fn(FlightInformationRegion $notifiedFir) => $notifiedFir->id === $flightInformationRegion->id))
+            ->filter(fn(FlightInformationRegion $flightInformationRegion) => !empty($flightInformationRegion->pivot->tag))
+            ->map(fn(FlightInformationRegion $flightInformationRegion) => new Tag($flightInformationRegion->pivot));
 
-        return empty($divisionWebhook->tag)
+        return $recipients->isEmpty()
             ? new NoRecipients()
-            : new DivisionWebhookRecipients(new Tag($divisionWebhook));
+            : new DivisionWebhookRecipients($recipients);
     }
 }

--- a/app/Models/DivisionDiscordWebhook.php
+++ b/app/Models/DivisionDiscordWebhook.php
@@ -22,7 +22,9 @@ class DivisionDiscordWebhook extends Model implements WebhookInterface, TagProvi
 
     public function flightInformationRegions(): BelongsToMany
     {
-        return $this->belongsToMany(FlightInformationRegion::class);
+        return $this->belongsToMany(FlightInformationRegion::class)
+            ->withTimestamps()
+            ->using(DivisionDiscordWebhookFlightInformationRegion::class);
     }
 
     public function id(): ?int

--- a/app/Models/DivisionDiscordWebhook.php
+++ b/app/Models/DivisionDiscordWebhook.php
@@ -9,21 +9,21 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
 
-class DivisionDiscordWebhook extends Model implements WebhookInterface, TagProviderInterface
+class DivisionDiscordWebhook extends Model implements WebhookInterface
 {
     use HasFactory;
     use SoftDeletes;
 
     protected $fillable = [
         'url',
-        'description',
-        'tag',
+        'description'
     ];
 
     public function flightInformationRegions(): BelongsToMany
     {
         return $this->belongsToMany(FlightInformationRegion::class)
             ->withTimestamps()
+            ->withPivot('tag')
             ->using(DivisionDiscordWebhookFlightInformationRegion::class);
     }
 
@@ -40,10 +40,5 @@ class DivisionDiscordWebhook extends Model implements WebhookInterface, TagProvi
     public function description(): string
     {
         return $this->description;
-    }
-
-    public function rawTagString(): string
-    {
-        return $this->tag;
     }
 }

--- a/app/Models/DivisionDiscordWebhook.php
+++ b/app/Models/DivisionDiscordWebhook.php
@@ -2,7 +2,6 @@
 
 namespace App\Models;
 
-use App\Discord\Message\Tag\TagProviderInterface;
 use App\Discord\Webhook\WebhookInterface;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;

--- a/app/Models/DivisionDiscordWebhookFlightInformationRegion.php
+++ b/app/Models/DivisionDiscordWebhookFlightInformationRegion.php
@@ -2,11 +2,17 @@
 
 namespace App\Models;
 
+use App\Discord\Message\Tag\TagProviderInterface;
 use Illuminate\Database\Eloquent\Relations\Pivot;
 
-class DivisionDiscordWebhookFlightInformationRegion extends Pivot
+class DivisionDiscordWebhookFlightInformationRegion extends Pivot implements TagProviderInterface
 {
     public $incrementing = true;
 
     public $timestamps = true;
+
+    public function rawTagString(): string
+    {
+        return (string)$this->tag;
+    }
 }

--- a/app/Models/DivisionDiscordWebhookFlightInformationRegion.php
+++ b/app/Models/DivisionDiscordWebhookFlightInformationRegion.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Relations\Pivot;
+
+class DivisionDiscordWebhookFlightInformationRegion extends Pivot
+{
+    public $incrementing = true;
+
+    public $timestamps = true;
+}

--- a/app/Models/FlightInformationRegion.php
+++ b/app/Models/FlightInformationRegion.php
@@ -59,6 +59,8 @@ class FlightInformationRegion extends Model
 
     public function divisionDiscordWebhooks(): BelongsToMany
     {
-        return $this->belongsToMany(DivisionDiscordWebhook::class);
+        return $this->belongsToMany(DivisionDiscordWebhook::class)
+            ->withTimestamps()
+            ->using(DivisionDiscordWebhookFlightInformationRegion::class);
     }
 }

--- a/app/Models/FlightInformationRegion.php
+++ b/app/Models/FlightInformationRegion.php
@@ -60,6 +60,7 @@ class FlightInformationRegion extends Model
     public function divisionDiscordWebhooks(): BelongsToMany
     {
         return $this->belongsToMany(DivisionDiscordWebhook::class)
+            ->withPivot('tag')
             ->withTimestamps()
             ->using(DivisionDiscordWebhookFlightInformationRegion::class);
     }

--- a/database/factories/DivisionDiscordWebhookFactory.php
+++ b/database/factories/DivisionDiscordWebhookFactory.php
@@ -21,13 +21,7 @@ class DivisionDiscordWebhookFactory extends Factory
     {
         return [
             'url' => $this->faker->url(),
-            'description' => $this->faker->sentence(3),
-            'tag' => sprintf('@%s', $this->faker->unique()->numberBetween(0, PHP_INT_MAX)),
+            'description' => $this->faker->sentence(3)
         ];
-    }
-
-    public function withNoTag(): static
-    {
-        return $this->state(fn (array $attributes) => ['tag' => '']);
     }
 }

--- a/database/migrations/2022_08_03_193646_add_tag_column_to_division_discord_webhook_flight_information_region_table.php
+++ b/database/migrations/2022_08_03_193646_add_tag_column_to_division_discord_webhook_flight_information_region_table.php
@@ -4,8 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class extends Migration
-{
+return new class () extends Migration {
     /**
      * Run the migrations.
      *

--- a/database/migrations/2022_08_03_193646_add_tag_column_to_division_discord_webhook_flight_information_region_table.php
+++ b/database/migrations/2022_08_03_193646_add_tag_column_to_division_discord_webhook_flight_information_region_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('division_discord_webhook_flight_information_region', function (Blueprint $table) {
+            $table->string('tag')
+                ->nullable()
+                ->after('flight_information_region_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('division_discord_webhook_flight_information_region', function (Blueprint $table) {
+            //
+        });
+    }
+};

--- a/database/migrations/2022_08_03_194127_migrate_division_discord_webhook_tags.php
+++ b/database/migrations/2022_08_03_194127_migrate_division_discord_webhook_tags.php
@@ -1,0 +1,59 @@
+<?php
+
+use App\Models\DivisionDiscordWebhook;
+use App\Models\FlightInformationRegion;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Migrations\Migration;
+
+return new class extends Migration {
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        // Migrate the existing tag values
+        FlightInformationRegion::all()
+            ->each(function (FlightInformationRegion $fir) {
+                $fir->divisionDiscordWebhooks
+                    ->each(function (DivisionDiscordWebhook $discordWebhook) use ($fir) {
+                        $fir->divisionDiscordWebhooks()->updateExistingPivot(
+                            $discordWebhook->id,
+                            ['tag' => $discordWebhook->tag]
+                        );
+                    });
+            });
+
+        // Deduplicate them by URL
+        DivisionDiscordWebhook::all()
+            ->groupBy('url')
+            ->reject(fn(Collection $webhooks) => $webhooks->count() === 1)
+            ->each(function (Collection $webhooks) {
+                // Get the one we're going to keep
+                $webhookToKeep = $webhooks->shift();
+
+                $webhooks->each(function (DivisionDiscordWebhook $webhook) use ($webhookToKeep) {
+                    // Migrate the FIRs to the main webhook
+                    $webhook->flightInformationRegions
+                        ->each(function (FlightInformationRegion $flightInformationRegion) use ($webhook, $webhookToKeep) {
+                            $flightInformationRegion->divisionDiscordWebhooks()
+                                ->attach($webhookToKeep->id, ['tag' => $webhook->tag]);
+                        });
+
+                    // Delete the webhooks
+                    $webhook->forceDelete();
+                });
+            });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        //
+    }
+};

--- a/database/migrations/2022_08_03_194127_migrate_division_discord_webhook_tags.php
+++ b/database/migrations/2022_08_03_194127_migrate_division_discord_webhook_tags.php
@@ -5,7 +5,7 @@ use App\Models\FlightInformationRegion;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Migrations\Migration;
 
-return new class extends Migration {
+return new class () extends Migration {
     /**
      * Run the migrations.
      *
@@ -28,7 +28,7 @@ return new class extends Migration {
         // Deduplicate them by URL
         DivisionDiscordWebhook::all()
             ->groupBy('url')
-            ->reject(fn(Collection $webhooks) => $webhooks->count() === 1)
+            ->reject(fn (Collection $webhooks) => $webhooks->count() === 1)
             ->each(function (Collection $webhooks) {
                 // Get the one we're going to keep
                 $webhookToKeep = $webhooks->shift();

--- a/database/migrations/2022_08_04_144847_drop_tag_column_from_division_discord_webhook_table.php
+++ b/database/migrations/2022_08_04_144847_drop_tag_column_from_division_discord_webhook_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('division_discord_webhooks', function (Blueprint $table) {
+            $table->dropColumn('tag');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+    }
+};

--- a/database/migrations/2022_08_04_144847_drop_tag_column_from_division_discord_webhook_table.php
+++ b/database/migrations/2022_08_04_144847_drop_tag_column_from_division_discord_webhook_table.php
@@ -4,8 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class extends Migration
-{
+return new class () extends Migration {
     /**
      * Run the migrations.
      *

--- a/tests/Discord/FlowMeasure/Content/DivisionWebhookRecipientsTest.php
+++ b/tests/Discord/FlowMeasure/Content/DivisionWebhookRecipientsTest.php
@@ -11,9 +11,11 @@ class DivisionWebhookRecipientsTest extends TestCase
 {
     public function testItReturnsRecipients()
     {
-        $this->assertSame(
-            '<@1234>',
-            (new DivisionWebhookRecipients(new Tag(new DiscordTag(['tag' => '1234']))))->toString()
+        $this->assertEquals(
+            '<@1234> <@5678>',
+            (new DivisionWebhookRecipients(
+                collect([new Tag(new DiscordTag(['tag' => '1234'])), new Tag(new DiscordTag(['tag' => '5678']))])
+            ))->toString()
         );
     }
 }


### PR DESCRIPTION
- Drop `tag` column from `division_discord_webhooks`
- Move that column onto the linking table between webhooks and FIRs
- Migrate existing tags to that table
- Deduplicate webhooks (they were duplicated for launch) by URL . 

Fix #213 