### PR TITLE
Drop unique index for flow measure identifiers

### DIFF
--- a/database/migrations/2022_10_17_183844_drop_unique_index_on_flow_measures_table.php
+++ b/database/migrations/2022_10_17_183844_drop_unique_index_on_flow_measures_table.php
@@ -4,8 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class extends Migration
-{
+return new class () extends Migration {
     /**
      * Run the migrations.
      *

--- a/database/migrations/2022_10_17_183844_drop_unique_index_on_flow_measures_table.php
+++ b/database/migrations/2022_10_17_183844_drop_unique_index_on_flow_measures_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('flow_measures', function (Blueprint $table) {
+            $indexes = Schema::getConnection()->getDoctrineSchemaManager()->listTableIndexes('flow_measures');
+            if (array_key_exists('flow_measures_identifier_unique', $indexes)) {
+                $table->dropUnique('flow_measures_identifier_unique');
+            }
+
+            $table->index('identifier');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        //
+    }
+};


### PR DESCRIPTION
In theory people can create flow measures months in advance, which mean duplicat e identifiers are possible.